### PR TITLE
사용자 인가 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,11 @@ build {
     dependsOn(copyDocument)
 }
 
+javadoc {
+    source = sourceSets.main.java.srcDirs
+    options.encoding = 'UTF-8'
+}
+
 //bootJar {
 //    archiveFileName = 'app.jar'
 //    dependsOn asciidoctor

--- a/src/docs/asciidoc/account.adoc
+++ b/src/docs/asciidoc/account.adoc
@@ -71,8 +71,12 @@ include::{snippets}/create-account/http-response.adoc[]
 
 ==== Request
 
+===== Request Header
+include::{snippets}/update-account/request-headers.adoc[]
+
 include::{snippets}/update-account/request-fields.adoc[]
 
+===== Path Parameters
 include::{snippets}/update-account/path-parameters.adoc[]
 
 ===== Request HTTP Example
@@ -94,6 +98,10 @@ include::{snippets}/update-account/http-response.adoc[]
 
 ==== Request
 
+===== Request Header
+include::{snippets}/delete-account/request-headers.adoc[]
+
+===== Path Parameters
 include::{snippets}/delete-account/path-parameters.adoc[]
 
 ===== Request HTTP Example

--- a/src/main/java/com/sedin/qna/account/controller/AccountController.java
+++ b/src/main/java/com/sedin/qna/account/controller/AccountController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -33,14 +34,16 @@ public class AccountController {
 
     @PatchMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponseDto<AccountDto.ResponseOne> update(@PathVariable Long id,
+    public ApiResponseDto<AccountDto.ResponseOne> update(@RequestAttribute Long accountId,
+                                                         @PathVariable Long id,
                                                          @RequestBody @Valid AccountDto.Update update) {
         return ApiResponseDto.OK(new AccountDto.ResponseOne(accountService.update(id, update)));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponseDto<String> delete(@PathVariable Long id) {
+    public ApiResponseDto<String> delete(@RequestAttribute Long accountId,
+                                         @PathVariable Long id) {
         accountService.delete(id);
         return ApiResponseDto.DEFAULT_OK;
     }

--- a/src/main/java/com/sedin/qna/account/controller/AccountController.java
+++ b/src/main/java/com/sedin/qna/account/controller/AccountController.java
@@ -37,14 +37,14 @@ public class AccountController {
     public ApiResponseDto<AccountDto.ResponseOne> update(@RequestAttribute Long accountId,
                                                          @PathVariable Long id,
                                                          @RequestBody @Valid AccountDto.Update update) {
-        return ApiResponseDto.OK(new AccountDto.ResponseOne(accountService.update(id, update)));
+        return ApiResponseDto.OK(new AccountDto.ResponseOne(accountService.update(accountId, id, update)));
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<String> delete(@RequestAttribute Long accountId,
                                          @PathVariable Long id) {
-        accountService.delete(id);
+        accountService.delete(accountId, id);
         return ApiResponseDto.DEFAULT_OK;
     }
 }

--- a/src/main/java/com/sedin/qna/account/service/AccountService.java
+++ b/src/main/java/com/sedin/qna/account/service/AccountService.java
@@ -6,7 +6,7 @@ public interface AccountService {
 
     AccountDto.Response signUp(AccountDto.Create create);
 
-    AccountDto.Response update(Long id, AccountDto.Update update);
+    AccountDto.Response update(Long accountId, Long id, AccountDto.Update update);
 
-    void delete(Long id);
+    void delete(Long accountId, Long id);
 }

--- a/src/main/java/com/sedin/qna/account/service/AccountServiceImpl.java
+++ b/src/main/java/com/sedin/qna/account/service/AccountServiceImpl.java
@@ -5,6 +5,7 @@ import com.sedin.qna.account.model.AccountDto;
 import com.sedin.qna.account.repository.AccountRepository;
 import com.sedin.qna.exception.DuplicatedException;
 import com.sedin.qna.exception.NotFoundException;
+import com.sedin.qna.exception.PermissionToAccessException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,7 +40,9 @@ public class AccountServiceImpl implements AccountService {
 
     @Override
     @Transactional
-    public AccountDto.Response update(Long id, AccountDto.Update update) {
+    public AccountDto.Response update(Long accountId, Long id, AccountDto.Update update) {
+        checkPermissionToAccess(accountId, id);
+
         Account updated = accountRepository.findById(id)
                 .map(update::complete)
                 .orElseThrow(() -> new NotFoundException(id.toString()));
@@ -48,10 +51,18 @@ public class AccountServiceImpl implements AccountService {
     }
 
     @Override
-    public void delete(Long id) {
+    public void delete(Long accountId, Long id) {
+        checkPermissionToAccess(accountId, id);
+
         Account account = accountRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(id.toString()));
 
         accountRepository.delete(account);
+    }
+
+    private static void checkPermissionToAccess(Long accountId, Long id) {
+        if (!accountId.equals(id)) {
+            throw new PermissionToAccessException();
+        }
     }
 }

--- a/src/main/java/com/sedin/qna/account/service/AccountServiceImpl.java
+++ b/src/main/java/com/sedin/qna/account/service/AccountServiceImpl.java
@@ -23,11 +23,11 @@ public class AccountServiceImpl implements AccountService {
     @Override
     public AccountDto.Response signUp(AccountDto.Create create) {
         if (accountRepository.existsByLoginId(create.getLoginId())) {
-            throw new DuplicatedException("loginId");
+            throw new DuplicatedException(create.getLoginId());
         }
 
         if (accountRepository.existsByEmail(create.getEmail())) {
-            throw new DuplicatedException("email");
+            throw new DuplicatedException(create.getEmail());
         }
 
         create.setEncodingPassword(passwordEncoder.encode(create.getPassword()));
@@ -42,7 +42,7 @@ public class AccountServiceImpl implements AccountService {
     public AccountDto.Response update(Long id, AccountDto.Update update) {
         Account updated = accountRepository.findById(id)
                 .map(update::complete)
-                .orElseThrow(() -> new NotFoundException("accountId"));
+                .orElseThrow(() -> new NotFoundException(id.toString()));
 
         return AccountDto.Response.of(updated);
     }
@@ -50,7 +50,7 @@ public class AccountServiceImpl implements AccountService {
     @Override
     public void delete(Long id) {
         Account account = accountRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("accountId"));
+                .orElseThrow(() -> new NotFoundException(id.toString()));
 
         accountRepository.delete(account);
     }

--- a/src/main/java/com/sedin/qna/advice/AuthorizedErrorAdvice.java
+++ b/src/main/java/com/sedin/qna/advice/AuthorizedErrorAdvice.java
@@ -1,5 +1,6 @@
 package com.sedin.qna.advice;
 
+import com.sedin.qna.exception.InvalidTokenException;
 import com.sedin.qna.exception.PasswordIncorrectException;
 import com.sedin.qna.network.ApiResponseCode;
 import com.sedin.qna.network.ApiResponseDto;
@@ -17,7 +18,7 @@ import java.util.Map;
 @RestControllerAdvice
 public class AuthorizedErrorAdvice {
 
-    private static final String ERROR_MESSAGE = "Password Incorrect Error";
+    private static final String MESSAGE = "message";
 
     /**
      * 패스워드가 틀릴 때 에러 메세지를 리턴합니다.
@@ -29,7 +30,21 @@ public class AuthorizedErrorAdvice {
     @ExceptionHandler(PasswordIncorrectException.class)
     public ApiResponseDto<Map<String, String>> handlePasswordIncorrect(PasswordIncorrectException exception) {
         Map<String, String> errorMap = new HashMap<>();
-        errorMap.put(exception.getMessage(), ERROR_MESSAGE);
+        errorMap.put(MESSAGE, exception.getMessage());
+
+        return ApiResponseDto.ERROR(ApiResponseCode.UNAUTHORIZED, errorMap);
+    }
+
+    /**
+     * 토큰이 유효하지 않을 때 에러 메세지를 리턴합니다.
+     * @param exception 토큰 유효성 예외
+     * @return 에러 응답
+     */
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(InvalidTokenException.class)
+    public ApiResponseDto<Map<String, String>> handleTokenInvalid(InvalidTokenException exception) {
+        Map<String, String> errorMap = new HashMap<>();
+        errorMap.put(MESSAGE, exception.getMessage());
 
         return ApiResponseDto.ERROR(ApiResponseCode.UNAUTHORIZED, errorMap);
     }

--- a/src/main/java/com/sedin/qna/advice/AuthorizedErrorAdvice.java
+++ b/src/main/java/com/sedin/qna/advice/AuthorizedErrorAdvice.java
@@ -2,6 +2,7 @@ package com.sedin.qna.advice;
 
 import com.sedin.qna.exception.InvalidTokenException;
 import com.sedin.qna.exception.PasswordIncorrectException;
+import com.sedin.qna.exception.PermissionToAccessException;
 import com.sedin.qna.network.ApiResponseCode;
 import com.sedin.qna.network.ApiResponseDto;
 import org.springframework.http.HttpStatus;
@@ -43,6 +44,20 @@ public class AuthorizedErrorAdvice {
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(InvalidTokenException.class)
     public ApiResponseDto<Map<String, String>> handleTokenInvalid(InvalidTokenException exception) {
+        Map<String, String> errorMap = new HashMap<>();
+        errorMap.put(MESSAGE, exception.getMessage());
+
+        return ApiResponseDto.ERROR(ApiResponseCode.UNAUTHORIZED, errorMap);
+    }
+
+    /**
+     * 리소스에 접근 권한이 없을 경우에 에러 메세지를 리턴합니다.
+     * @param exception 리소스
+     * @return 에러 응답
+     */
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(PermissionToAccessException.class)
+    public ApiResponseDto<Map<String, String>> handlePermissionToAccess(PermissionToAccessException exception) {
         Map<String, String> errorMap = new HashMap<>();
         errorMap.put(MESSAGE, exception.getMessage());
 

--- a/src/main/java/com/sedin/qna/advice/DuplicatedErrorAdvice.java
+++ b/src/main/java/com/sedin/qna/advice/DuplicatedErrorAdvice.java
@@ -17,7 +17,7 @@ import java.util.Map;
 @RestControllerAdvice
 public class DuplicatedErrorAdvice {
 
-    private static final String ERROR_MESSAGE = "Duplicated Error";
+    private static final String MESSAGE = "message";
 
     /**
      * 사용자 등록 요청 데이터가 중복일 때 에러 메세지를 리턴합니다.
@@ -29,7 +29,7 @@ public class DuplicatedErrorAdvice {
     @ExceptionHandler(DuplicatedException.class)
     public ApiResponseDto<Map<String, String>> handleAccountAlreadyExisted(DuplicatedException exception) {
         Map<String, String> errorMap = new HashMap<>();
-        errorMap.put(exception.getMessage(), ERROR_MESSAGE);
+        errorMap.put(MESSAGE, exception.getMessage());
 
         return ApiResponseDto.ERROR(ApiResponseCode.DUPLICATED_ERROR, errorMap);
     }

--- a/src/main/java/com/sedin/qna/advice/NotFoundErrorAdvice.java
+++ b/src/main/java/com/sedin/qna/advice/NotFoundErrorAdvice.java
@@ -17,7 +17,7 @@ import java.util.Map;
 @RestControllerAdvice
 public class NotFoundErrorAdvice {
 
-    private static final String ERROR_MESSAGE = "Not Found Error";
+    private static final String MESSAGE = "message";
 
     /**
      * 사용자를 찾을 수 없을 때 에러 메세지를 리턴합니다.
@@ -29,7 +29,7 @@ public class NotFoundErrorAdvice {
     @ExceptionHandler(NotFoundException.class)
     public ApiResponseDto<Map<String, String>> handleAccountNotFound(NotFoundException exception) {
         Map<String, String> errorMap = new HashMap<>();
-        errorMap.put(exception.getMessage(), ERROR_MESSAGE);
+        errorMap.put(MESSAGE, exception.getMessage());
 
         return ApiResponseDto.ERROR(ApiResponseCode.NOT_FOUND, errorMap);
     }

--- a/src/main/java/com/sedin/qna/athentication/service/AuthenticationService.java
+++ b/src/main/java/com/sedin/qna/athentication/service/AuthenticationService.java
@@ -8,4 +8,6 @@ public interface AuthenticationService {
     AuthenticationDto.Response checkValidAuthentication(AccountDto.Login login);
 
     Long decodeAccessToken(String accessToken);
+
+    String getAccessToken(String authorization);
 }

--- a/src/main/java/com/sedin/qna/athentication/service/AuthenticationService.java
+++ b/src/main/java/com/sedin/qna/athentication/service/AuthenticationService.java
@@ -6,4 +6,6 @@ import com.sedin.qna.athentication.model.AuthenticationDto;
 public interface AuthenticationService {
 
     AuthenticationDto.Response checkValidAuthentication(AccountDto.Login login);
+
+    Long decodeAccessToken(String accessToken);
 }

--- a/src/main/java/com/sedin/qna/athentication/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/sedin/qna/athentication/service/AuthenticationServiceImpl.java
@@ -4,6 +4,7 @@ import com.sedin.qna.account.model.Account;
 import com.sedin.qna.account.model.AccountDto;
 import com.sedin.qna.account.repository.AccountRepository;
 import com.sedin.qna.athentication.model.AuthenticationDto;
+import com.sedin.qna.exception.InvalidTokenException;
 import com.sedin.qna.exception.NotFoundException;
 import com.sedin.qna.exception.PasswordIncorrectException;
 import com.sedin.qna.util.JwtUtil;
@@ -12,6 +13,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class AuthenticationServiceImpl implements AuthenticationService {
+
+    private final String BEARER = "Bearer ";
 
     private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
@@ -38,6 +41,15 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     @Override
     public Long decodeAccessToken(String accessToken) {
         return Long.valueOf(jwtUtil.decode(accessToken).get("accountId").toString());
+    }
+
+    @Override
+    public String getAccessToken(String authorization) {
+        if (authorization == null || !authorization.startsWith(BEARER)) {
+            throw new InvalidTokenException();
+        }
+
+        return authorization.substring(BEARER.length());
     }
 
     private boolean isUnauthenticated(String rawPassword, String encodedPassword) {

--- a/src/main/java/com/sedin/qna/athentication/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/sedin/qna/athentication/service/AuthenticationServiceImpl.java
@@ -26,13 +26,18 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     @Override
     public AuthenticationDto.Response checkValidAuthentication(AccountDto.Login login) {
         Account account = accountRepository.findByLoginId(login.getLoginId())
-                .orElseThrow(() -> new NotFoundException("loginId"));
+                .orElseThrow(() -> new NotFoundException(login.getLoginId()));
 
         if (isUnauthenticated(login.getPassword(), account.getPassword())) {
-            throw new PasswordIncorrectException("password");
+            throw new PasswordIncorrectException();
         }
 
         return AuthenticationDto.Response.of(jwtUtil.encode(account.getId()));
+    }
+
+    @Override
+    public Long decodeAccessToken(String accessToken) {
+        return Long.valueOf(jwtUtil.decode(accessToken).get("accountId").toString());
     }
 
     private boolean isUnauthenticated(String rawPassword, String encodedPassword) {

--- a/src/main/java/com/sedin/qna/config/WebConfigInterceptors.java
+++ b/src/main/java/com/sedin/qna/config/WebConfigInterceptors.java
@@ -15,7 +15,6 @@ public class WebConfigInterceptors implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
-                .excludePathPatterns("/docs")
-                .excludePathPatterns("/api/auth/*");
+                .excludePathPatterns("/favicon.ico", "/api/docs/*", "/api/auth/*");
     }
 }

--- a/src/main/java/com/sedin/qna/config/WebConfigInterceptors.java
+++ b/src/main/java/com/sedin/qna/config/WebConfigInterceptors.java
@@ -1,0 +1,21 @@
+package com.sedin.qna.config;
+
+import com.sedin.qna.interceptor.AuthenticationInterceptor;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class WebConfigInterceptors implements WebMvcConfigurer {
+
+    private final AuthenticationInterceptor authenticationInterceptor;
+
+    public WebConfigInterceptors(AuthenticationInterceptor authenticationInterceptor) {
+        this.authenticationInterceptor = authenticationInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authenticationInterceptor)
+                .excludePathPatterns("/docs")
+                .excludePathPatterns("/api/auth/*");
+    }
+}

--- a/src/main/java/com/sedin/qna/config/WebMvcConfig.java
+++ b/src/main/java/com/sedin/qna/config/WebMvcConfig.java
@@ -1,8 +1,8 @@
 package com.sedin.qna.config;
 
 import com.sedin.qna.interceptor.AuthenticationInterceptor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -20,10 +20,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addResourceHandler("/api/docs/**").addResourceLocations("classpath:/static/docs/");
     }
 
-    @Override
-    public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(authenticationInterceptor)
-                .excludePathPatterns("/docs")
-                .excludePathPatterns("/api/auth/*");
+    @Bean
+    public WebMvcConfigurer webMvcConfigurerInterceptors() {
+        return new WebConfigInterceptors(authenticationInterceptor);
     }
 }

--- a/src/main/java/com/sedin/qna/config/WebMvcConfig.java
+++ b/src/main/java/com/sedin/qna/config/WebMvcConfig.java
@@ -7,11 +7,11 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class WebMvcConfiguration implements WebMvcConfigurer {
+public class WebMvcConfig implements WebMvcConfigurer {
 
     private final AuthenticationInterceptor authenticationInterceptor;
 
-    public WebMvcConfiguration(AuthenticationInterceptor authenticationInterceptor) {
+    public WebMvcConfig(AuthenticationInterceptor authenticationInterceptor) {
         this.authenticationInterceptor = authenticationInterceptor;
     }
 
@@ -22,6 +22,8 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(authenticationInterceptor);
+        registry.addInterceptor(authenticationInterceptor)
+                .excludePathPatterns("/docs")
+                .excludePathPatterns("/api/auth/*");
     }
 }

--- a/src/main/java/com/sedin/qna/config/WebMvcConfiguration.java
+++ b/src/main/java/com/sedin/qna/config/WebMvcConfiguration.java
@@ -1,14 +1,27 @@
 package com.sedin.qna.config;
 
+import com.sedin.qna.interceptor.AuthenticationInterceptor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
+    private final AuthenticationInterceptor authenticationInterceptor;
+
+    public WebMvcConfiguration(AuthenticationInterceptor authenticationInterceptor) {
+        this.authenticationInterceptor = authenticationInterceptor;
+    }
+
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/api/docs/**").addResourceLocations("classpath:/static/docs/");
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authenticationInterceptor);
     }
 }

--- a/src/main/java/com/sedin/qna/exception/DuplicatedException.java
+++ b/src/main/java/com/sedin/qna/exception/DuplicatedException.java
@@ -1,7 +1,7 @@
 package com.sedin.qna.exception;
 
 /**
- * 리소스가 중복일 때 던집니다.
+ * 리소스가 중복일 경우에 던집니다.
  */
 public class DuplicatedException extends RuntimeException {
 

--- a/src/main/java/com/sedin/qna/exception/DuplicatedException.java
+++ b/src/main/java/com/sedin/qna/exception/DuplicatedException.java
@@ -5,7 +5,9 @@ package com.sedin.qna.exception;
  */
 public class DuplicatedException extends RuntimeException {
 
-    public DuplicatedException(String message) {
-        super(message);
+    private static final String DUPLICATED_MESSAGE = "Duplicated Resource: ";
+
+    public DuplicatedException(String resource) {
+        super(DUPLICATED_MESSAGE + resource);
     }
 }

--- a/src/main/java/com/sedin/qna/exception/InvalidTokenException.java
+++ b/src/main/java/com/sedin/qna/exception/InvalidTokenException.java
@@ -5,7 +5,9 @@ package com.sedin.qna.exception;
  */
 public class InvalidTokenException extends RuntimeException {
 
-    public InvalidTokenException(String token) {
-        super("Invalid token: " + token);
+    private static final String INVALID_TOKEN = "Invalid token";
+
+    public InvalidTokenException() {
+        super(INVALID_TOKEN);
     }
 }

--- a/src/main/java/com/sedin/qna/exception/NotFoundException.java
+++ b/src/main/java/com/sedin/qna/exception/NotFoundException.java
@@ -5,7 +5,9 @@ package com.sedin.qna.exception;
  */
 public class NotFoundException extends RuntimeException {
 
-    public NotFoundException(String message) {
-        super(message);
+    private static final String NOT_FOUND = "Not Found: ";
+
+    public NotFoundException(String resource) {
+        super(NOT_FOUND + resource);
     }
 }

--- a/src/main/java/com/sedin/qna/exception/NotFoundException.java
+++ b/src/main/java/com/sedin/qna/exception/NotFoundException.java
@@ -1,7 +1,7 @@
 package com.sedin.qna.exception;
 
 /**
- * 리소스를 찾을 수 없을 때 던집니다.
+ * 리소스를 찾을 수 없을 경우에 던집니다.
  */
 public class NotFoundException extends RuntimeException {
 

--- a/src/main/java/com/sedin/qna/exception/PasswordIncorrectException.java
+++ b/src/main/java/com/sedin/qna/exception/PasswordIncorrectException.java
@@ -5,7 +5,9 @@ package com.sedin.qna.exception;
  */
 public class PasswordIncorrectException extends RuntimeException {
 
-    public PasswordIncorrectException(String message) {
-        super(message);
+    private static final String INCORRECT_PASSWORD = "Incorrect Password";
+
+    public PasswordIncorrectException() {
+        super(INCORRECT_PASSWORD);
     }
 }

--- a/src/main/java/com/sedin/qna/exception/PermissionToAccessException.java
+++ b/src/main/java/com/sedin/qna/exception/PermissionToAccessException.java
@@ -1,0 +1,13 @@
+package com.sedin.qna.exception;
+
+/**
+ * 리소스에 접근 권한이 없을 경우에 던집니다.
+ */
+public class PermissionToAccessException extends RuntimeException {
+
+    private static final String UNAUTHORIZED_MESSAGE = "There is no permission to access that resource";
+
+    public PermissionToAccessException() {
+        super(UNAUTHORIZED_MESSAGE);
+    }
+}

--- a/src/main/java/com/sedin/qna/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/sedin/qna/interceptor/AuthenticationInterceptor.java
@@ -1,7 +1,6 @@
 package com.sedin.qna.interceptor;
 
 import com.sedin.qna.athentication.service.AuthenticationService;
-import com.sedin.qna.exception.InvalidTokenException;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -14,7 +13,6 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
     private final String ACCOUNT_ID = "accountId";
     private final String AUTHORIZATION = "Authorization";
-    private final String BEARER = "Bearer ";
 
     private final AuthenticationService authenticationService;
 
@@ -31,13 +29,10 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         }
 
         String authorization = request.getHeader(AUTHORIZATION);
+        String accessToken = authenticationService.getAccessToken(authorization);
+        Long accountId = authenticationService.decodeAccessToken(accessToken);
 
-        if (!authorization.startsWith(BEARER)) {
-            throw new InvalidTokenException();
-        }
-
-        String accessToken = authorization.substring(BEARER.length());
-        request.setAttribute(ACCOUNT_ID, authenticationService.decodeAccessToken(accessToken));
+        request.setAttribute(ACCOUNT_ID, accountId);
 
         return true;
     }

--- a/src/main/java/com/sedin/qna/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/sedin/qna/interceptor/AuthenticationInterceptor.java
@@ -1,7 +1,7 @@
 package com.sedin.qna.interceptor;
 
+import com.sedin.qna.athentication.service.AuthenticationService;
 import com.sedin.qna.exception.InvalidTokenException;
-import com.sedin.qna.util.JwtUtil;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -16,10 +16,10 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     private final String AUTHORIZATION = "Authorization";
     private final String BEARER = "Bearer ";
 
-    private final JwtUtil jwtUtil;
+    private final AuthenticationService authenticationService;
 
-    public AuthenticationInterceptor(JwtUtil jwtUtil) {
-        this.jwtUtil = jwtUtil;
+    public AuthenticationInterceptor(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
     }
 
     @Override
@@ -30,10 +30,6 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        if (request.getRequestURI().startsWith("/api/auth/login") && request.getMethod().equals(HttpMethod.POST.toString())) {
-            return true;
-        }
-
         String authorization = request.getHeader(AUTHORIZATION);
 
         if (!authorization.startsWith(BEARER)) {
@@ -41,7 +37,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         }
 
         String accessToken = authorization.substring(BEARER.length());
-        request.setAttribute(ACCOUNT_ID, jwtUtil.decode(accessToken).get(ACCOUNT_ID));
+        request.setAttribute(ACCOUNT_ID, authenticationService.decodeAccessToken(accessToken));
 
         return true;
     }

--- a/src/main/java/com/sedin/qna/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/sedin/qna/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,48 @@
+package com.sedin.qna.interceptor;
+
+import com.sedin.qna.exception.InvalidTokenException;
+import com.sedin.qna.util.JwtUtil;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private final String ACCOUNT_ID = "accountId";
+    private final String AUTHORIZATION = "Authorization";
+    private final String BEARER = "Bearer ";
+
+    private final JwtUtil jwtUtil;
+
+    public AuthenticationInterceptor(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+                             Object handler) throws Exception {
+
+        if (request.getRequestURI().startsWith("/api/accounts") && request.getMethod().equals(HttpMethod.POST.toString())) {
+            return true;
+        }
+
+        if (request.getRequestURI().startsWith("/api/auth/login") && request.getMethod().equals(HttpMethod.POST.toString())) {
+            return true;
+        }
+
+        String authorization = request.getHeader(AUTHORIZATION);
+
+        if (!authorization.startsWith(BEARER)) {
+            throw new InvalidTokenException();
+        }
+
+        String accessToken = authorization.substring(BEARER.length());
+        request.setAttribute(ACCOUNT_ID, jwtUtil.decode(accessToken).get(ACCOUNT_ID));
+
+        return true;
+    }
+}

--- a/src/main/java/com/sedin/qna/util/JwtUtil.java
+++ b/src/main/java/com/sedin/qna/util/JwtUtil.java
@@ -28,7 +28,7 @@ public class JwtUtil {
 
     public Claims decode(String token) {
         if (token == null || StringUtils.isBlank(token)) {
-            throw new InvalidTokenException(token);
+            throw new InvalidTokenException();
         }
 
         try {
@@ -38,7 +38,7 @@ public class JwtUtil {
                     .parseClaimsJws(token)
                     .getBody();
         } catch (SignatureException e) {
-            throw new InvalidTokenException(token);
+            throw new InvalidTokenException();
         }
     }
 }

--- a/src/test/java/com/sedin/qna/account/controller/AccountControllerWebTest.java
+++ b/src/test/java/com/sedin/qna/account/controller/AccountControllerWebTest.java
@@ -29,6 +29,7 @@ import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.PayloadDocumentation;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -51,6 +52,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
@@ -63,6 +66,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AccountController.class)
@@ -329,6 +333,7 @@ class AccountControllerWebTest {
                             .andDo(document("update-account",
                                     ApiDocumentUtil.getDocumentRequest(),
                                     ApiDocumentUtil.getDocumentResponse(),
+                                    requestHeaders(headerWithName(AUTHORIZATION).description("Basic auth credentials")),
                                     pathParameters(parameterWithName("id").description("업데이트할 사용자 id")),
                                     requestFields(
                                             fieldWithPath("originalPassword").type(JsonFieldType.STRING).description("기존 비밀번호"),
@@ -370,9 +375,10 @@ class AccountControllerWebTest {
                     String requestBody = objectMapper.writeValueAsString(updateDtoWithEmptyArgument);
 
                     mockMvc.perform(patch("/api/accounts/" + EXISTED_ID)
+                                    .header(AUTHORIZATION, VALID_TOKEN)
+                                    .content(requestBody)
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .characterEncoding(StandardCharsets.UTF_8)
-                                    .content(requestBody))
+                                    .characterEncoding(StandardCharsets.UTF_8))
                             .andExpect(status().isBadRequest());
 
                     verify(accountService, never())
@@ -431,13 +437,15 @@ class AccountControllerWebTest {
                 @DisplayName("HttpStatus 200 OK를 응답한다")
                 void it_returns_httpStatus_OK() throws Exception {
                     ResultActions result = mockMvc.perform(
-                            RestDocumentationRequestBuilders.delete("/api/accounts/{id}", EXISTED_ID));
+                            RestDocumentationRequestBuilders.delete("/api/accounts/{id}", EXISTED_ID)
+                                    .header(AUTHORIZATION, VALID_TOKEN));
 
                     // Delete Account RestDocs
                     result.andExpect(status().isOk())
                             .andDo(document("delete-account",
                                     ApiDocumentUtil.getDocumentRequest(),
                                     ApiDocumentUtil.getDocumentResponse(),
+                                    requestHeaders(headerWithName(AUTHORIZATION).description("Basic auth credentials")),
                                     pathParameters(parameterWithName("id").description("삭제할 사용자 id"))
                             ));
 

--- a/src/test/java/com/sedin/qna/account/controller/AccountControllerWebTest.java
+++ b/src/test/java/com/sedin/qna/account/controller/AccountControllerWebTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sedin.qna.account.model.AccountDto;
 import com.sedin.qna.account.model.Gender;
 import com.sedin.qna.account.service.AccountService;
+import com.sedin.qna.athentication.service.AuthenticationService;
 import com.sedin.qna.exception.DuplicatedException;
 import com.sedin.qna.exception.NotFoundException;
 import com.sedin.qna.util.ApiDocumentUtil;
@@ -79,6 +80,9 @@ class AccountControllerWebTest {
 
     @MockBean
     private AccountService accountService;
+
+    @MockBean
+    private AuthenticationService authenticationService;
 
     private AccountDto.Create createDto;
     private AccountDto.Create registeredDto;

--- a/src/test/java/com/sedin/qna/account/controller/AccountControllerWebTest.java
+++ b/src/test/java/com/sedin/qna/account/controller/AccountControllerWebTest.java
@@ -344,7 +344,7 @@ class AccountControllerWebTest {
                         .build();
 
                 given(accountService.update(eq(NOT_EXISTED_ID), any(AccountDto.Update.class)))
-                        .willThrow(new NotFoundException("accountId"));
+                        .willThrow(new NotFoundException(NOT_EXISTED_ID.toString()));
             }
 
             @Test
@@ -380,7 +380,8 @@ class AccountControllerWebTest {
             @Test
             @DisplayName("HttpStatus 200 OK를 응답한다")
             void it_returns_httpStatus_OK() throws Exception {
-                ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/accounts/{id}", EXISTED_ID));
+                ResultActions result = mockMvc.perform(
+                        RestDocumentationRequestBuilders.delete("/api/accounts/{id}", EXISTED_ID));
 
                 // Delete Account RestDocs
                 result.andExpect(status().isOk())
@@ -400,7 +401,7 @@ class AccountControllerWebTest {
 
             @BeforeEach
             void prepareNotExistedAccountId() {
-                doThrow(new NotFoundException("accountId")).when(accountService).delete(NOT_EXISTED_ID);
+                doThrow(new NotFoundException(NOT_EXISTED_ID.toString())).when(accountService).delete(NOT_EXISTED_ID);
             }
 
             @Test

--- a/src/test/java/com/sedin/qna/account/service/AccountServiceTest.java
+++ b/src/test/java/com/sedin/qna/account/service/AccountServiceTest.java
@@ -192,7 +192,7 @@ class AccountServiceTest {
             @Test
             @DisplayName("사용자를 수정하고 Account 정보를 담은 응답을 리턴한다")
             void it_returns_response_with_updated_account() {
-                response = accountService.update(EXISTED_ID, updateDto);
+                response = accountService.update(EXISTED_ID, EXISTED_ID, updateDto);
 
                 assertThat(response.getEmail()).isEqualTo(NEW_EMAIL);
                 verify(accountRepository, times(1)).findById(any(Long.class));
@@ -206,7 +206,7 @@ class AccountServiceTest {
             @Test
             @DisplayName("사용자를 삭제한다")
             void it_deletes_account() {
-                accountService.delete(EXISTED_ID);
+                accountService.delete(EXISTED_ID, EXISTED_ID);
                 verify(accountRepository, times(1)).delete(any(Account.class));
             }
         }
@@ -232,7 +232,7 @@ class AccountServiceTest {
             @Test
             @DisplayName("NotFoundException 예외를 던진다")
             void it_returns_notFoundException() {
-                assertThatThrownBy(() -> accountService.update(NOT_EXISTED_ID, updateDto))
+                assertThatThrownBy(() -> accountService.update(NOT_EXISTED_ID, NOT_EXISTED_ID, updateDto))
                         .isExactlyInstanceOf(NotFoundException.class);
 
                 verify(accountRepository, times(1)).findById(any(Long.class));
@@ -247,7 +247,7 @@ class AccountServiceTest {
             @Test
             @DisplayName("NotFoundException 예외를 던진다")
             void it_returns_notFoundException() {
-                assertThatThrownBy(() -> accountService.delete(NOT_EXISTED_ID))
+                assertThatThrownBy(() -> accountService.delete(NOT_EXISTED_ID, NOT_EXISTED_ID))
                         .isExactlyInstanceOf(NotFoundException.class);
 
                 verify(accountRepository, times(1)).findById(any(Long.class));

--- a/src/test/java/com/sedin/qna/api/document/CommonDocumentationTest.java
+++ b/src/test/java/com/sedin/qna/api/document/CommonDocumentationTest.java
@@ -2,6 +2,7 @@ package com.sedin.qna.api.document;
 
 import com.sedin.qna.account.model.Gender;
 import com.sedin.qna.api.document.controller.RestDocsController;
+import com.sedin.qna.athentication.service.AuthenticationService;
 import com.sedin.qna.network.ApiResponseCode;
 import com.sedin.qna.util.CustomResponseFieldsSnippet;
 import com.sedin.qna.util.EnumType;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.FieldDescriptor;
@@ -37,6 +39,9 @@ public class CommonDocumentationTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private AuthenticationService authenticationService;
 
     @Test
     void common() throws Exception {

--- a/src/test/java/com/sedin/qna/athentication/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/sedin/qna/athentication/controller/AuthenticationControllerTest.java
@@ -125,7 +125,7 @@ class AuthenticationControllerTest {
                 .build();
 
         given(authenticationService.checkValidAuthentication(any(AccountDto.Login.class)))
-                .willThrow(new PasswordIncorrectException("password"));
+                .willThrow(new PasswordIncorrectException());
 
         // when
         String requestBody = objectMapper.writeValueAsString(login);
@@ -151,7 +151,7 @@ class AuthenticationControllerTest {
                 .build();
 
         given(authenticationService.checkValidAuthentication(any(AccountDto.Login.class)))
-                .willThrow(new NotFoundException("loginId"));
+                .willThrow(new NotFoundException(UNREGISTERED_LOGIN_ID));
 
         // when
         String requestBody = objectMapper.writeValueAsString(login);

--- a/src/test/java/com/sedin/qna/athentication/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/sedin/qna/athentication/service/AuthenticationServiceTest.java
@@ -97,7 +97,7 @@ class AuthenticationServiceTest {
                 .password(PASSWORD)
                 .build();
 
-        given(accountRepository.findByLoginId(anyString())).willThrow(new NotFoundException("loginId"));
+        given(accountRepository.findByLoginId(anyString())).willThrow(new NotFoundException(UNREGISTERED_LOGIN_ID));
 
         // when & then
         assertThatThrownBy(() -> authenticationService.checkValidAuthentication(loginWithUnregisteredLoginId))


### PR DESCRIPTION
- 사용자 인가 기능 구현
<br/>

- [X] : AuthenticationInterceptor 인터셉터
     - [X] : 인터셉터에서 Client가 Header에 key: Authorization, value: "Bearer ..."담아 보낸 AccessToken을 파싱하여 유효성 검사
     - [X] : WebConfigInterceptors 에서 인터셉터 제외할 path 추가

- [X] : 인터셉터가 추가되면서 인가된 사용자만 API를 사용할 수 있도록 수정
     - [X] : Patch /api/accounts/{id} - 사용자 자신은 자신의 정보만 수정 가능
     - [X] : Delete /api/accounts/{id} - 사용자 자신은 자신만 회원 탈퇴 가능
    


Closes #7 