### PR TITLE
게시글 조회수 기능 구현

### DIFF
--- a/src/main/java/com/sedin/qna/account/service/AccountServiceImpl.java
+++ b/src/main/java/com/sedin/qna/account/service/AccountServiceImpl.java
@@ -50,5 +50,4 @@ public class AccountServiceImpl implements AccountService {
         return accountRepository.findByEmail(email)
                 .orElseThrow(() -> new NotFoundException(email));
     }
-
 }

--- a/src/main/java/com/sedin/qna/article/comment/model/Comment.java
+++ b/src/main/java/com/sedin/qna/article/comment/model/Comment.java
@@ -56,13 +56,16 @@ public class Comment extends BaseTimeEntity {
         return this;
     }
 
-    public void attachArticle(Article article) {
-        if (this.article != null) {
-            this.article.getComments().remove(this);
-        }
-        
+    public void attachToArticle(Account account, Article article) {
+        this.author = account.getName();
+        this.account = account;
         this.article = article;
         article.getComments().add(this);
         article.plusCommentsCount();
+    }
+
+    public void detachToArticle() {
+        this.article.getComments().remove(this);
+        this.article.minusCommentsCount();
     }
 }

--- a/src/main/java/com/sedin/qna/article/comment/model/Comment.java
+++ b/src/main/java/com/sedin/qna/article/comment/model/Comment.java
@@ -57,6 +57,10 @@ public class Comment extends BaseTimeEntity {
     }
 
     public void attachToArticle(Account account, Article article) {
+        if (this.article != null) {
+            article.getComments().remove(this);
+        }
+
         this.author = account.getName();
         this.account = account;
         this.article = article;

--- a/src/main/java/com/sedin/qna/article/comment/model/CommentDto.java
+++ b/src/main/java/com/sedin/qna/article/comment/model/CommentDto.java
@@ -30,16 +30,10 @@ public class CommentDto {
             this.content = content;
         }
 
-        public Comment toEntity(Account account, Article article) {
-            Comment comment = Comment.builder()
+        public Comment toEntity() {
+            return Comment.builder()
                     .content(content)
-                    .author(account.getName())
-                    .account(account)
                     .build();
-
-            comment.attachArticle(article);
-
-            return comment;
         }
     }
 
@@ -56,10 +50,6 @@ public class CommentDto {
         @Builder
         private Update(String content) {
             this.content = content;
-        }
-
-        public Comment apply(Comment comment) {
-            return comment.update(content);
         }
     }
 

--- a/src/main/java/com/sedin/qna/article/model/Article.java
+++ b/src/main/java/com/sedin/qna/article/model/Article.java
@@ -76,4 +76,8 @@ public class Article extends BaseTimeEntity {
     public void minusCommentsCount() {
         this.commentsCount--;
     }
+
+    public void increaseArticleViewCount() {
+        this.articleViewCount++;
+    }
 }

--- a/src/main/java/com/sedin/qna/article/model/Article.java
+++ b/src/main/java/com/sedin/qna/article/model/Article.java
@@ -44,6 +44,9 @@ public class Article extends BaseTimeEntity {
     @Column(nullable = false)
     private Long commentsCount = 0L;
 
+    @Column(nullable = false)
+    private Long articleViewCount = 0L;
+
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 

--- a/src/main/java/com/sedin/qna/article/model/ArticleDto.java
+++ b/src/main/java/com/sedin/qna/article/model/ArticleDto.java
@@ -75,6 +75,7 @@ public class ArticleDto {
         private String content;
         private String author;
         private Long commentsCount;
+        private Long articleViewCount;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
         private LocalDateTime createdAt;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
@@ -82,12 +83,13 @@ public class ArticleDto {
 
         @Builder
         private ResponseChange(Long id, String title, String content, String author, Long commentsCount,
-                               LocalDateTime createdAt, LocalDateTime modifiedAt) {
+                               Long articleViewCount, LocalDateTime createdAt, LocalDateTime modifiedAt) {
             this.id = id;
             this.title = title;
             this.content = content;
             this.author = author;
             this.commentsCount = commentsCount;
+            this.articleViewCount = articleViewCount;
             this.createdAt = createdAt;
             this.modifiedAt = modifiedAt;
         }
@@ -99,6 +101,7 @@ public class ArticleDto {
                     .content(article.getContent())
                     .author(article.getAuthor())
                     .commentsCount(article.getCommentsCount())
+                    .articleViewCount(article.getArticleViewCount())
                     .createdAt(article.getCreatedAt())
                     .modifiedAt(article.getModifiedAt())
                     .build();
@@ -112,6 +115,7 @@ public class ArticleDto {
         private String title;
         private String author;
         private Long commentsCount;
+        private Long articleViewCount;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
         private LocalDateTime createdAt;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
@@ -119,11 +123,12 @@ public class ArticleDto {
 
         @Builder
         private ResponseAll(Long id, String title, String author, Long commentsCount,
-                            LocalDateTime createdAt, LocalDateTime modifiedAt) {
+                            Long articleViewCount, LocalDateTime createdAt, LocalDateTime modifiedAt) {
             this.id = id;
             this.title = title;
             this.author = author;
             this.commentsCount = commentsCount;
+            this.articleViewCount = articleViewCount;
             this.createdAt = createdAt;
             this.modifiedAt = modifiedAt;
         }
@@ -134,6 +139,7 @@ public class ArticleDto {
                     .title(article.getTitle())
                     .author(article.getAuthor())
                     .commentsCount(article.getCommentsCount())
+                    .articleViewCount(article.getArticleViewCount())
                     .createdAt(article.getCreatedAt())
                     .modifiedAt(article.getModifiedAt())
                     .build();
@@ -148,6 +154,7 @@ public class ArticleDto {
         private String content;
         private String author;
         private Long commentsCount;
+        private Long articleViewCount;
         private List<CommentDto.Response> comments;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
         private LocalDateTime createdAt;
@@ -156,12 +163,14 @@ public class ArticleDto {
 
         @Builder
         private ResponseDetail(Long id, String title, String content, String author, Long commentsCount,
-                               List<CommentDto.Response> comments, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+                               Long articleViewCount, List<CommentDto.Response> comments,
+                               LocalDateTime createdAt, LocalDateTime modifiedAt) {
             this.id = id;
             this.title = title;
             this.content = content;
             this.author = author;
             this.commentsCount = commentsCount;
+            this.articleViewCount = articleViewCount;
             this.comments = comments;
             this.createdAt = createdAt;
             this.modifiedAt = modifiedAt;
@@ -174,6 +183,7 @@ public class ArticleDto {
                     .content(article.getContent())
                     .author(article.getAuthor())
                     .commentsCount(article.getCommentsCount())
+                    .articleViewCount(article.getArticleViewCount())
                     .comments(article.getComments().stream().map(CommentDto.Response::of).collect(Collectors.toList()))
                     .createdAt(article.getCreatedAt())
                     .modifiedAt(article.getModifiedAt())

--- a/src/main/java/com/sedin/qna/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sedin/qna/article/service/ArticleServiceImpl.java
@@ -1,7 +1,7 @@
 package com.sedin.qna.article.service;
 
 import com.sedin.qna.account.model.Account;
-import com.sedin.qna.account.service.AccountService;
+import com.sedin.qna.account.repository.AccountRepository;
 import com.sedin.qna.article.model.Article;
 import com.sedin.qna.article.model.ArticleDto;
 import com.sedin.qna.article.repository.ArticleRepository;
@@ -20,12 +20,12 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ArticleServiceImpl implements ArticleService {
 
-    private final AccountService accountService;
+    private final AccountRepository accountRepository;
     private final ArticleRepository articleRepository;
 
     @Override
     public ArticleDto.ResponseChange create(String email, ArticleDto.Create create) {
-        Account account = accountService.findAccount(email);
+        Account account = findAccount(email);
         Article article = create.toEntity(account);
         return ArticleDto.ResponseChange.of(articleRepository.save(article));
     }
@@ -47,7 +47,7 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     public ArticleDto.ResponseChange update(String email, Long id, ArticleDto.Update update) {
-        Account account = accountService.findAccount(email);
+        Account account = findAccount(email);
         Article article = findArticle(id);
         checkPermissionBetweenAccountAndAuthor(account, article.getAccount());
 
@@ -56,7 +56,7 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     public void delete(String email, Long id) {
-        Account account = accountService.findAccount(email);
+        Account account = findAccount(email);
         Article article = findArticle(id);
         checkPermissionBetweenAccountAndAuthor(account, article.getAccount());
 
@@ -68,6 +68,11 @@ public class ArticleServiceImpl implements ArticleService {
         return articleRepository.findAllEntityGraph(pageable).stream()
                 .map(ArticleDto.ResponseDetail::of)
                 .collect(Collectors.toList());
+    }
+
+    public Account findAccount(String email) {
+        return accountRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(email));
     }
 
     private Article findArticle(Long id) {

--- a/src/main/java/com/sedin/qna/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sedin/qna/article/service/ArticleServiceImpl.java
@@ -39,9 +39,10 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public ArticleDto.ResponseDetail findById(Long id) {
-        return ArticleDto.ResponseDetail.of(findArticle(id));
+        Article article = findArticle(id);
+        article.increaseArticleViewCount();
+        return ArticleDto.ResponseDetail.of(article);
     }
 
     @Override

--- a/src/main/java/com/sedin/qna/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/sedin/qna/authentication/service/AuthenticationService.java
@@ -21,6 +21,8 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class AuthenticationService {
 
+    private static final String PREFIX = "ROLE_";
+
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final AccountRepository accountRepository;
@@ -33,7 +35,7 @@ public class AuthenticationService {
         }
 
         List<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(new SimpleGrantedAuthority("ROLES_" + account.getRole().name()));
+        authorities.add(new SimpleGrantedAuthority(PREFIX + account.getRole().name()));
         return AuthenticationDto.Response.of(jwtTokenProvider.encode(account.getEmail(), authorities));
     }
 

--- a/src/main/java/com/sedin/qna/common/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/sedin/qna/common/configuration/SecurityConfiguration.java
@@ -47,10 +47,8 @@ public class SecurityConfiguration {
                 .authorizeRequests()
                 .antMatchers(HttpMethod.POST, "/api/accounts", "/api/login").permitAll()
                 .antMatchers(HttpMethod.GET, "/api/articles/**").permitAll()
-                .antMatchers("/api/articles/**").hasRole("USER")
                 .antMatchers(HttpMethod.GET, "/api/docs/**", "/favicon.ico").permitAll()
                 .antMatchers("/**").authenticated()
-                .anyRequest().permitAll()
                 .and()
                 .formLogin().disable();
 

--- a/src/test/java/com/sedin/qna/article/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/sedin/qna/article/comment/service/CommentServiceTest.java
@@ -1,7 +1,7 @@
 package com.sedin.qna.article.comment.service;
 
 import com.sedin.qna.account.model.Account;
-import com.sedin.qna.account.service.AccountService;
+import com.sedin.qna.account.repository.AccountRepository;
 import com.sedin.qna.article.comment.model.Comment;
 import com.sedin.qna.article.comment.model.CommentDto;
 import com.sedin.qna.article.comment.repository.CommentRepository;
@@ -39,7 +39,7 @@ class CommentServiceTest {
     private static final String TITLE = "title";
 
     @MockBean
-    private AccountService accountService = mock(AccountService.class);
+    private AccountRepository accountRepository = mock(AccountRepository.class);
 
     @MockBean
     private ArticleRepository articleRepository = mock(ArticleRepository.class);
@@ -54,7 +54,7 @@ class CommentServiceTest {
 
     @BeforeEach
     void prepare() {
-        commentService = new CommentServiceImpl(accountService, articleRepository, commentRepository);
+        commentService = new CommentServiceImpl(accountRepository, articleRepository, commentRepository);
 
         authenticatedAccount = Account.builder()
                 .id(1L)
@@ -84,9 +84,9 @@ class CommentServiceTest {
                 .account(authenticatedAccount)
                 .build();
 
-        given(accountService.findAccount(EMAIL)).willReturn(authenticatedAccount);
+        given(accountRepository.findByEmail(EMAIL)).willReturn(Optional.of(authenticatedAccount));
         given(articleRepository.findById(anyLong())).willReturn(Optional.of(article));
-        given(commentRepository.save(any())).willReturn(comment);
+        given(commentRepository.save(any(Comment.class))).willReturn(comment);
 
         // when
         CommentDto.Response response = commentService.create(EMAIL, ARTICLE_ID, create);
@@ -95,7 +95,7 @@ class CommentServiceTest {
         assertThat(response.getContent()).isEqualTo(CONTENT);
         assertThat(response.getAuthor()).isEqualTo(NAME);
 
-        verify(commentRepository, times(1)).save(any());
+        verify(commentRepository, times(1)).save(any(Comment.class));
     }
 
     @Test
@@ -173,7 +173,7 @@ class CommentServiceTest {
                 .content(PREFIX + CONTENT)
                 .build();
 
-        given(accountService.findAccount(EMAIL)).willReturn(authenticatedAccount);
+        given(accountRepository.findByEmail(EMAIL)).willReturn(Optional.of(authenticatedAccount));
         given(commentRepository.findByArticleIdAndId(anyLong(), anyLong())).willReturn(Optional.of(comment));
 
         // when
@@ -194,7 +194,7 @@ class CommentServiceTest {
                 .account(authenticatedAccount)
                 .build();
 
-        given(accountService.findAccount(EMAIL)).willReturn(authenticatedAccount);
+        given(accountRepository.findByEmail(EMAIL)).willReturn(Optional.of(authenticatedAccount));
         given(commentRepository.findByArticleIdAndId(anyLong(), anyLong())).willReturn(Optional.of(comment));
         doNothing().when(commentRepository).delete(comment);
 

--- a/src/test/java/com/sedin/qna/article/controller/ArticleControllerWebTest.java
+++ b/src/test/java/com/sedin/qna/article/controller/ArticleControllerWebTest.java
@@ -122,6 +122,7 @@ class ArticleControllerWebTest {
                 .content(CONTENT)
                 .author(AUTHOR)
                 .commentsCount(0L)
+                .articleViewCount(0L)
                 .createdAt(LocalDateTime.now())
                 .modifiedAt(LocalDateTime.now())
                 .build();
@@ -163,6 +164,7 @@ class ArticleControllerWebTest {
                                         fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
                                         fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
                                         fieldWithPath("commentsCount").type(JsonFieldType.NUMBER).description("댓글 수"),
+                                        fieldWithPath("articleViewCount").type(JsonFieldType.NUMBER).description("조회 수"),
                                         fieldWithPath("author").type(JsonFieldType.STRING).description("작성자"),
                                         fieldWithPath("createdAt").type(JsonFieldType.STRING)
                                                 .attributes(DocumentFormatGenerator.getDateFormat())
@@ -185,6 +187,7 @@ class ArticleControllerWebTest {
                         .title(TITLE)
                         .author(AUTHOR)
                         .commentsCount(0L)
+                        .articleViewCount(0L)
                         .createdAt(LocalDateTime.now())
                         .modifiedAt(LocalDateTime.now())
                         .build(),
@@ -193,6 +196,7 @@ class ArticleControllerWebTest {
                         .title(TITLE)
                         .author(AUTHOR)
                         .commentsCount(0L)
+                        .articleViewCount(0L)
                         .createdAt(LocalDateTime.now())
                         .modifiedAt(LocalDateTime.now())
                         .build()
@@ -225,6 +229,7 @@ class ArticleControllerWebTest {
                                         fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
                                         fieldWithPath("author").type(JsonFieldType.STRING).description("작성자"),
                                         fieldWithPath("commentsCount").type(JsonFieldType.NUMBER).description("댓글 수"),
+                                        fieldWithPath("articleViewCount").type(JsonFieldType.NUMBER).description("조회 수"),
                                         fieldWithPath("createdAt").type(JsonFieldType.STRING)
                                                 .attributes(DocumentFormatGenerator.getDateFormat())
                                                 .description("생성시간"),
@@ -246,6 +251,7 @@ class ArticleControllerWebTest {
                 .content(CONTENT)
                 .author(AUTHOR)
                 .commentsCount(0L)
+                .articleViewCount(0L)
                 .comments(new ArrayList<>())
                 .createdAt(LocalDateTime.now())
                 .modifiedAt(LocalDateTime.now())
@@ -274,6 +280,7 @@ class ArticleControllerWebTest {
                                         fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
                                         fieldWithPath("author").type(JsonFieldType.STRING).description("작성자"),
                                         fieldWithPath("commentsCount").type(JsonFieldType.NUMBER).description("댓글 수"),
+                                        fieldWithPath("articleViewCount").type(JsonFieldType.NUMBER).description("조회 수"),
                                         fieldWithPath("comments").type(JsonFieldType.ARRAY).description("댓글"),
                                         fieldWithPath("createdAt").type(JsonFieldType.STRING)
                                                 .attributes(DocumentFormatGenerator.getDateFormat())
@@ -297,6 +304,7 @@ class ArticleControllerWebTest {
                 .content(PREFIX + CONTENT)
                 .author(AUTHOR)
                 .commentsCount(0L)
+                .articleViewCount(0L)
                 .createdAt(LocalDateTime.now())
                 .modifiedAt(LocalDateTime.now())
                 .build();
@@ -339,6 +347,7 @@ class ArticleControllerWebTest {
                                         fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
                                         fieldWithPath("author").type(JsonFieldType.STRING).description("작성자"),
                                         fieldWithPath("commentsCount").type(JsonFieldType.NUMBER).description("댓글 수"),
+                                        fieldWithPath("articleViewCount").type(JsonFieldType.NUMBER).description("조회 수"),
                                         fieldWithPath("createdAt").type(JsonFieldType.STRING)
                                                 .attributes(DocumentFormatGenerator.getDateFormat())
                                                 .description("생성시간"),

--- a/src/test/java/com/sedin/qna/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/sedin/qna/article/service/ArticleServiceTest.java
@@ -133,11 +133,13 @@ class ArticleServiceTest {
         given(articleRepository.findById(anyLong())).willReturn(Optional.of(article));
 
         // when
+        articleService.findById(1L);
         ArticleDto.ResponseDetail response = articleService.findById(1L);
 
         // then
         assertThat(response.getId()).isEqualTo(1L);
         assertThat(response.getAuthor()).isEqualTo(NAME);
+        assertThat(response.getArticleViewCount()).isSameAs(2L);
     }
 
     @Test

--- a/src/test/java/com/sedin/qna/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/sedin/qna/article/service/ArticleServiceTest.java
@@ -1,8 +1,7 @@
 package com.sedin.qna.article.service;
 
 import com.sedin.qna.account.model.Account;
-import com.sedin.qna.account.service.AccountService;
-import com.sedin.qna.account.service.AccountServiceImpl;
+import com.sedin.qna.account.repository.AccountRepository;
 import com.sedin.qna.article.model.Article;
 import com.sedin.qna.article.model.ArticleDto;
 import com.sedin.qna.article.repository.ArticleRepository;
@@ -42,7 +41,7 @@ class ArticleServiceTest {
     private ArticleService articleService;
 
     @MockBean
-    private AccountService accountService = mock(AccountServiceImpl.class);
+    private AccountRepository accountRepository = mock(AccountRepository.class);
 
     @MockBean
     private ArticleRepository articleRepository = mock(ArticleRepository.class);
@@ -51,7 +50,7 @@ class ArticleServiceTest {
 
     @BeforeEach
     void prepare() {
-        articleService = new ArticleServiceImpl(accountService, articleRepository);
+        articleService = new ArticleServiceImpl(accountRepository, articleRepository);
 
         authenticatedAccount = Account.builder()
                 .id(1L)
@@ -75,7 +74,7 @@ class ArticleServiceTest {
                 .account(authenticatedAccount)
                 .build();
 
-        given(accountService.findAccount(EMAIL)).willReturn(authenticatedAccount);
+        given(accountRepository.findByEmail(EMAIL)).willReturn(Optional.of(authenticatedAccount));
         given(articleRepository.save(any())).willReturn(article);
 
         // when
@@ -168,7 +167,7 @@ class ArticleServiceTest {
                 .content(PREFIX + CONTENT)
                 .build();
 
-        given(accountService.findAccount(EMAIL)).willReturn(authenticatedAccount);
+        given(accountRepository.findByEmail(EMAIL)).willReturn(Optional.of(authenticatedAccount));
         given(articleRepository.findById(1L)).willReturn(Optional.of(article));
 
         // when
@@ -191,7 +190,7 @@ class ArticleServiceTest {
                 .account(authenticatedAccount)
                 .build();
 
-        given(accountService.findAccount(EMAIL)).willReturn(authenticatedAccount);
+        given(accountRepository.findByEmail(EMAIL)).willReturn(Optional.of(authenticatedAccount));
         given(articleRepository.findById(1L)).willReturn(Optional.of(article));
         doNothing().when(articleRepository).delete(article);
 

--- a/src/test/java/com/sedin/qna/authentication/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/sedin/qna/authentication/service/AuthenticationServiceTest.java
@@ -73,7 +73,7 @@ class AuthenticationServiceTest {
                 .password(PASSWORD)
                 .build();
 
-        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLES_" + account.getRole().name()));
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + account.getRole().name()));
 
         given(accountRepository.findByEmail(EMAIL)).willReturn(Optional.of(account));
         given(passwordEncoder.matches(eq(PASSWORD), any(String.class))).willReturn(true);


### PR DESCRIPTION
- 게시글 조회 수 기능 구현
- [x] : Article 테이블에 조회 수(article_view_count) 컬럼 추가
- [x] : 컬럼 추가에 따른 Article Entity, Dto 변경
- [x] : Article 상세 조회 API에서 조회 수 증가 기능 구현
- [x] : 변경으로 인해 깨지는 테스트 수정
- [x] : 조회 수 기능 구현부 테스트

closes #25  