### PR TITLE
게시글 추천 수 기능 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    # 테스트용 Properties 생성 & 작성
+    - name: Create Test-Properties
+      run: touch ./src/main/resources/application-test.properties
+
+    - name: Write Test-Properties
+      run: echo "${{ secrets.TEST_PROPERTIES }}" > ./src/main/resources/application-test.properties
+
     # 로컬 서버용 Properties 생성 & 작성
     - name: Create Local-Properties
       run: touch ./src/main/resources/application-local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
     // Database
     runtimeOnly 'com.h2database:h2'
-//    implementation 'mysql:mysql-connector-java:8.0.31'
+    implementation 'mysql:mysql-connector-java:8.0.31'
 
 
     // Jwt

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -35,4 +35,6 @@ API에 관계없이 아래 사항을 지켜주셔야 합니다.
 
 === link:./article.html[Article API]
 
+=== link:./recommend-article.html[Recommend Article API]
+
 === link:./comment.html[Comment API]

--- a/src/docs/asciidoc/recommend-article.adoc
+++ b/src/docs/asciidoc/recommend-article.adoc
@@ -1,0 +1,78 @@
+ifndef::snippets[]
+:snippets: ../build/generated-snippets
+endif::[]
+= API Document
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+
+=== link:./index.html[Home]
+
+[[introduction]]
+== 소개
+
+게시글 추천 API
+
+[[common]]
+== 공통 사항
+
+=== Common Response
+
+include::{snippets}/common/custom-response-fields.adoc[]
+
+include::{snippets}/common/custom-response-fields-apiResponseCodes.adoc[]
+
+
+&#160;
+
+
+== 게시글 추천 API
+
+[[Recommend-Article-create]]
+=== 추가
+
+==== Request
+
+include::{snippets}/create-recommend-article/request-headers.adoc[]
+
+include::{snippets}/create-recommend-article/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/create-recommend-article/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/create-recommend-article/response-body.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/create-recommend-article/http-response.adoc[]
+
+&#160;
+
+[[Recommend-Article-delete]]
+=== 삭제
+
+==== Request
+
+===== Request Header
+include::{snippets}/delete-recommend-article/request-headers.adoc[]
+
+===== Path Parameters
+include::{snippets}/delete-recommend-article/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/delete-recommend-article/http-request.adoc[]
+
+==== Response
+
+===== Response HTTP Example
+
+include::{snippets}/delete-recommend-article/http-response.adoc[]
+
+&#160;

--- a/src/main/java/com/sedin/qna/account/model/Account.java
+++ b/src/main/java/com/sedin/qna/account/model/Account.java
@@ -10,12 +10,13 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
 @Entity
 @Getter
-@Table(name = "Account")
+@Table(name = "account")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Account {
 

--- a/src/main/java/com/sedin/qna/article/model/Article.java
+++ b/src/main/java/com/sedin/qna/article/model/Article.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Table(name = "Article")
+@Table(name = "article")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Article extends BaseTimeEntity {
 

--- a/src/main/java/com/sedin/qna/article/model/Article.java
+++ b/src/main/java/com/sedin/qna/article/model/Article.java
@@ -1,7 +1,7 @@
 package com.sedin.qna.article.model;
 
 import com.sedin.qna.account.model.Account;
-import com.sedin.qna.article.comment.model.Comment;
+import com.sedin.qna.comment.model.Comment;
 import com.sedin.qna.common.model.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/sedin/qna/article/model/ArticleDto.java
+++ b/src/main/java/com/sedin/qna/article/model/ArticleDto.java
@@ -2,7 +2,7 @@ package com.sedin.qna.article.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sedin.qna.account.model.Account;
-import com.sedin.qna.article.comment.model.CommentDto;
+import com.sedin.qna.comment.model.CommentDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/sedin/qna/comment/controller/CommentController.java
+++ b/src/main/java/com/sedin/qna/comment/controller/CommentController.java
@@ -1,7 +1,7 @@
-package com.sedin.qna.article.comment.controller;
+package com.sedin.qna.comment.controller;
 
-import com.sedin.qna.article.comment.model.CommentDto;
-import com.sedin.qna.article.comment.service.CommentService;
+import com.sedin.qna.comment.model.CommentDto;
+import com.sedin.qna.comment.service.CommentService;
 import com.sedin.qna.common.response.ApiResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/sedin/qna/comment/model/Comment.java
+++ b/src/main/java/com/sedin/qna/comment/model/Comment.java
@@ -20,7 +20,7 @@ import javax.persistence.Table;
 
 @Entity
 @Getter
-@Table(name = "Comment")
+@Table(name = "comment")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseTimeEntity {
 

--- a/src/main/java/com/sedin/qna/comment/model/Comment.java
+++ b/src/main/java/com/sedin/qna/comment/model/Comment.java
@@ -1,4 +1,4 @@
-package com.sedin.qna.article.comment.model;
+package com.sedin.qna.comment.model;
 
 import com.sedin.qna.account.model.Account;
 import com.sedin.qna.article.model.Article;

--- a/src/main/java/com/sedin/qna/comment/model/CommentDto.java
+++ b/src/main/java/com/sedin/qna/comment/model/CommentDto.java
@@ -1,8 +1,6 @@
-package com.sedin.qna.article.comment.model;
+package com.sedin.qna.comment.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.sedin.qna.account.model.Account;
-import com.sedin.qna.article.model.Article;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/sedin/qna/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sedin/qna/comment/repository/CommentRepository.java
@@ -1,6 +1,6 @@
-package com.sedin.qna.article.comment.repository;
+package com.sedin.qna.comment.repository;
 
-import com.sedin.qna.article.comment.model.Comment;
+import com.sedin.qna.comment.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/sedin/qna/comment/service/CommentService.java
+++ b/src/main/java/com/sedin/qna/comment/service/CommentService.java
@@ -1,6 +1,6 @@
-package com.sedin.qna.article.comment.service;
+package com.sedin.qna.comment.service;
 
-import com.sedin.qna.article.comment.model.CommentDto;
+import com.sedin.qna.comment.model.CommentDto;
 
 import java.util.List;
 

--- a/src/main/java/com/sedin/qna/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sedin/qna/comment/service/CommentServiceImpl.java
@@ -1,12 +1,12 @@
-package com.sedin.qna.article.comment.service;
+package com.sedin.qna.comment.service;
 
 import com.sedin.qna.account.model.Account;
 import com.sedin.qna.account.repository.AccountRepository;
 import com.sedin.qna.article.model.Article;
 import com.sedin.qna.article.repository.ArticleRepository;
-import com.sedin.qna.article.comment.model.Comment;
-import com.sedin.qna.article.comment.model.CommentDto;
-import com.sedin.qna.article.comment.repository.CommentRepository;
+import com.sedin.qna.comment.model.Comment;
+import com.sedin.qna.comment.model.CommentDto;
+import com.sedin.qna.comment.repository.CommentRepository;
 import com.sedin.qna.common.exception.NotFoundException;
 import com.sedin.qna.common.exception.PermissionToAccessException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/sedin/qna/recommendarticle/controller/RecommendArticleController.java
+++ b/src/main/java/com/sedin/qna/recommendarticle/controller/RecommendArticleController.java
@@ -1,0 +1,29 @@
+package com.sedin.qna.recommendarticle.controller;
+
+import com.sedin.qna.common.response.ApiResponseDto;
+import com.sedin.qna.recommendarticle.service.RecommendArticleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/articles/{articleId}/recommend")
+public class RecommendArticleController {
+
+    private final RecommendArticleService recommendArticleService;
+
+    @PostMapping
+    public ApiResponseDto<String> create(@AuthenticationPrincipal String email, @PathVariable Long articleId) {
+        return recommendArticleService.createRecommendArticle(email, articleId);
+    }
+
+    @DeleteMapping
+    public ApiResponseDto<String> delete(@AuthenticationPrincipal String email, @PathVariable Long articleId) {
+        return recommendArticleService.deleteRecommendArticle(email, articleId);
+    }
+}

--- a/src/main/java/com/sedin/qna/recommendarticle/controller/RecommendArticleController.java
+++ b/src/main/java/com/sedin/qna/recommendarticle/controller/RecommendArticleController.java
@@ -3,11 +3,13 @@ package com.sedin.qna.recommendarticle.controller;
 import com.sedin.qna.common.response.ApiResponseDto;
 import com.sedin.qna.recommendarticle.service.RecommendArticleService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,11 +20,13 @@ public class RecommendArticleController {
     private final RecommendArticleService recommendArticleService;
 
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponseDto<String> create(@AuthenticationPrincipal String email, @PathVariable Long articleId) {
         return recommendArticleService.createRecommendArticle(email, articleId);
     }
 
     @DeleteMapping
+    @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<String> delete(@AuthenticationPrincipal String email, @PathVariable Long articleId) {
         return recommendArticleService.deleteRecommendArticle(email, articleId);
     }

--- a/src/main/java/com/sedin/qna/recommendarticle/model/RecommendArticle.java
+++ b/src/main/java/com/sedin/qna/recommendarticle/model/RecommendArticle.java
@@ -1,0 +1,45 @@
+package com.sedin.qna.recommendarticle.model;
+
+import com.sedin.qna.account.model.Account;
+import com.sedin.qna.article.model.Article;
+import com.sedin.qna.common.model.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Getter
+@Table(name = "recommend_article")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecommendArticle extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "recommend_article_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id")
+    private Article article;
+
+    @Builder
+    private RecommendArticle(Long id, Account account, Article article) {
+        this.id = id;
+        this.account = account;
+        this.article = article;
+    }
+}

--- a/src/main/java/com/sedin/qna/recommendarticle/repository/RecommendArticleRepository.java
+++ b/src/main/java/com/sedin/qna/recommendarticle/repository/RecommendArticleRepository.java
@@ -1,0 +1,17 @@
+package com.sedin.qna.recommendarticle.repository;
+
+import com.sedin.qna.account.model.Account;
+import com.sedin.qna.article.model.Article;
+import com.sedin.qna.recommendarticle.model.RecommendArticle;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RecommendArticleRepository extends JpaRepository<RecommendArticle, Long> {
+
+    boolean existsByAccountAndArticle(Account account, Article article);
+
+    Optional<RecommendArticle> findByAccountAndArticle(Account account, Article article);
+}

--- a/src/main/java/com/sedin/qna/recommendarticle/service/RecommendArticleService.java
+++ b/src/main/java/com/sedin/qna/recommendarticle/service/RecommendArticleService.java
@@ -1,0 +1,10 @@
+package com.sedin.qna.recommendarticle.service;
+
+import com.sedin.qna.common.response.ApiResponseDto;
+
+public interface RecommendArticleService {
+
+    ApiResponseDto<String> createRecommendArticle(String email, Long articleId);
+
+    ApiResponseDto<String> deleteRecommendArticle(String email, Long articleId);
+}

--- a/src/main/java/com/sedin/qna/recommendarticle/service/RecommendArticleServiceImpl.java
+++ b/src/main/java/com/sedin/qna/recommendarticle/service/RecommendArticleServiceImpl.java
@@ -1,0 +1,67 @@
+package com.sedin.qna.recommendarticle.service;
+
+import com.sedin.qna.account.model.Account;
+import com.sedin.qna.account.repository.AccountRepository;
+import com.sedin.qna.article.model.Article;
+import com.sedin.qna.article.repository.ArticleRepository;
+import com.sedin.qna.common.exception.DuplicatedException;
+import com.sedin.qna.common.exception.NotFoundException;
+import com.sedin.qna.common.response.ApiResponseDto;
+import com.sedin.qna.recommendarticle.model.RecommendArticle;
+import com.sedin.qna.recommendarticle.repository.RecommendArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RecommendArticleServiceImpl implements RecommendArticleService {
+
+    private final AccountRepository accountRepository;
+    private final ArticleRepository articleRepository;
+    private final RecommendArticleRepository recommendArticleRepository;
+
+    @Override
+    public ApiResponseDto<String> createRecommendArticle(String email, Long articleId) {
+        Account account = findAccount(email);
+        Article article = findArticle(articleId);
+
+        if (recommendArticleRepository.existsByAccountAndArticle(account, article)) {
+            throw new DuplicatedException("Already registered resource");
+        }
+
+        RecommendArticle recommendArticle = RecommendArticle.builder()
+                .account(account)
+                .article(article)
+                .build();
+
+        recommendArticleRepository.save(recommendArticle);
+        return ApiResponseDto.DEFAULT_OK;
+    }
+
+    @Override
+    public ApiResponseDto<String> deleteRecommendArticle(String email, Long articleId) {
+        Account account = findAccount(email);
+        Article article = findArticle(articleId);
+        RecommendArticle recommendArticle = findRecommendArticle(account, article);
+        recommendArticleRepository.delete(recommendArticle);
+
+        return ApiResponseDto.DEFAULT_OK;
+    }
+
+    private Account findAccount(String email) {
+        return accountRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(email));
+    }
+
+    private Article findArticle(Long articleId) {
+        return articleRepository.findById(articleId)
+                .orElseThrow(() -> new NotFoundException(articleId.toString()));
+    }
+
+    private RecommendArticle findRecommendArticle(Account account, Article article) {
+        return recommendArticleRepository.findByAccountAndArticle(account, article)
+                .orElseThrow(() -> new NotFoundException("추천을 찾을 수 없음"));
+    }
+}

--- a/src/test/java/com/sedin/qna/account/controller/AccountControllerWebTest.java
+++ b/src/test/java/com/sedin/qna/account/controller/AccountControllerWebTest.java
@@ -34,6 +34,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
@@ -127,6 +128,7 @@ class AccountControllerWebTest {
     void setUp(RestDocumentationContextProvider restDocumentation) {
         this.mockMvc = MockMvcBuilders
                 .webAppContextSetup(context)
+                .addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
                 .defaultResponseCharacterEncoding(StandardCharsets.UTF_8)
                 .apply(springSecurity())
                 .apply(documentationConfiguration(restDocumentation))

--- a/src/test/java/com/sedin/qna/account/repository/AccountRepositoryTest.java
+++ b/src/test/java/com/sedin/qna/account/repository/AccountRepositoryTest.java
@@ -7,10 +7,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles("test")
 @DataJpaTest
 @ExtendWith(SpringExtension.class)
 class AccountRepositoryTest {

--- a/src/test/java/com/sedin/qna/article/controller/ArticleControllerWebTest.java
+++ b/src/test/java/com/sedin/qna/article/controller/ArticleControllerWebTest.java
@@ -1,7 +1,6 @@
 package com.sedin.qna.article.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sedin.qna.account.model.Account;
 import com.sedin.qna.article.model.ArticleDto;
 import com.sedin.qna.article.service.ArticleService;
 import com.sedin.qna.authentication.service.JwtTokenProvider;
@@ -24,12 +23,11 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -72,7 +70,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureRestDocs(uriScheme = "https", uriHost = "docs.api.com")
 class ArticleControllerWebTest {
 
-    private static final Long AUTHORIZED_ID = 1L;
     private static final String PREFIX = "prefix";
     private static final String EMAIL = "cafe@mocha.com";
     private static final String TITLE = "title";
@@ -94,27 +91,20 @@ class ArticleControllerWebTest {
     @MockBean
     private ArticleService articleService;
 
-    private Account authenticatedAccount;
-
     @BeforeEach
     void setUp(RestDocumentationContextProvider restDocumentation) {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(context)
+                .addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
                 .defaultResponseCharacterEncoding(StandardCharsets.UTF_8)
                 .apply(springSecurity())
                 .apply(documentationConfiguration(restDocumentation))
-                .build();
-
-        authenticatedAccount = Account.builder()
-                .id(AUTHORIZED_ID)
                 .build();
     }
 
     @Test
     @WithCustomMockUser
     void When_Request_Create_Article_With_Post_Method_Expect_HttpStatus_Is_Created() throws Exception {
-
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         // given
         ArticleDto.ResponseChange response = ArticleDto.ResponseChange.builder()
                 .id(1L)

--- a/src/test/java/com/sedin/qna/comment/controller/CommentControllerWebTest.java
+++ b/src/test/java/com/sedin/qna/comment/controller/CommentControllerWebTest.java
@@ -1,8 +1,6 @@
 package com.sedin.qna.comment.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sedin.qna.account.model.Account;
-import com.sedin.qna.comment.controller.CommentController;
 import com.sedin.qna.comment.model.CommentDto;
 import com.sedin.qna.comment.service.CommentService;
 import com.sedin.qna.authentication.service.JwtTokenProvider;
@@ -28,6 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -68,7 +67,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureRestDocs(uriScheme = "https", uriHost = "docs.api.com")
 class CommentControllerWebTest {
 
-    private static final Long AUTHORIZED_ID = 1L;
     private static final Long ARTICLE_ID = 1L;
     private static final String AUTHORIZATION = "Authorization";
     private static final String EMAIL = "cafe@mocha.com";
@@ -89,19 +87,14 @@ class CommentControllerWebTest {
     @MockBean
     private CommentService commentService;
 
-    private Account authenticatedAccount;
-
     @BeforeEach
     void setUp(RestDocumentationContextProvider restDocumentation) {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(context)
+                .addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
                 .defaultResponseCharacterEncoding(StandardCharsets.UTF_8)
                 .apply(springSecurity())
                 .apply(documentationConfiguration(restDocumentation))
-                .build();
-
-        authenticatedAccount = Account.builder()
-                .id(AUTHORIZED_ID)
                 .build();
     }
 

--- a/src/test/java/com/sedin/qna/comment/controller/CommentControllerWebTest.java
+++ b/src/test/java/com/sedin/qna/comment/controller/CommentControllerWebTest.java
@@ -1,9 +1,10 @@
-package com.sedin.qna.article.comment.controller;
+package com.sedin.qna.comment.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sedin.qna.account.model.Account;
-import com.sedin.qna.article.comment.model.CommentDto;
-import com.sedin.qna.article.comment.service.CommentService;
+import com.sedin.qna.comment.controller.CommentController;
+import com.sedin.qna.comment.model.CommentDto;
+import com.sedin.qna.comment.service.CommentService;
 import com.sedin.qna.authentication.service.JwtTokenProvider;
 import com.sedin.qna.common.configuration.SecurityConfiguration;
 import com.sedin.qna.common.response.ApiResponseCode;

--- a/src/test/java/com/sedin/qna/comment/model/CommentTest.java
+++ b/src/test/java/com/sedin/qna/comment/model/CommentTest.java
@@ -1,5 +1,6 @@
-package com.sedin.qna.article.comment.model;
+package com.sedin.qna.comment.model;
 
+import com.sedin.qna.comment.model.Comment;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/sedin/qna/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/sedin/qna/comment/service/CommentServiceTest.java
@@ -1,12 +1,14 @@
-package com.sedin.qna.article.comment.service;
+package com.sedin.qna.comment.service;
 
 import com.sedin.qna.account.model.Account;
 import com.sedin.qna.account.repository.AccountRepository;
-import com.sedin.qna.article.comment.model.Comment;
-import com.sedin.qna.article.comment.model.CommentDto;
-import com.sedin.qna.article.comment.repository.CommentRepository;
+import com.sedin.qna.comment.model.Comment;
+import com.sedin.qna.comment.model.CommentDto;
+import com.sedin.qna.comment.repository.CommentRepository;
 import com.sedin.qna.article.model.Article;
 import com.sedin.qna.article.repository.ArticleRepository;
+import com.sedin.qna.comment.service.CommentService;
+import com.sedin.qna.comment.service.CommentServiceImpl;
 import com.sedin.qna.common.exception.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/sedin/qna/recommendarticle/controller/RecommendArticleControllerTest.java
+++ b/src/test/java/com/sedin/qna/recommendarticle/controller/RecommendArticleControllerTest.java
@@ -1,0 +1,147 @@
+package com.sedin.qna.recommendarticle.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sedin.qna.account.model.Account;
+import com.sedin.qna.authentication.service.JwtTokenProvider;
+import com.sedin.qna.common.configuration.SecurityConfiguration;
+import com.sedin.qna.common.response.ApiResponseDto;
+import com.sedin.qna.configuration.WithCustomMockUser;
+import com.sedin.qna.recommendarticle.service.RecommendArticleService;
+import com.sedin.qna.util.ApiDocumentUtil;
+import com.sedin.qna.util.DocumentFormatGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RecommendArticleController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@ExtendWith({RestDocumentationExtension.class})
+@Import({
+        SecurityConfiguration.class,
+        JwtTokenProvider.class
+})
+@AutoConfigureRestDocs(uriScheme = "https", uriHost = "docs.api.com")
+class RecommendArticleControllerTest {
+
+    private static final Long ARTICLE_ID = 1L;
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String VALID_TOKEN = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJhY2NvdW50SWQiOjF9." +
+            "LwF0Ms-3xGGJX9JBIrc7bzGl1gYUAq3R3gesg35BA1w";
+    private static final String EMAIL = "cafe@mocha.com";
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RecommendArticleService recommendArticleService;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
+                .defaultResponseCharacterEncoding(StandardCharsets.UTF_8)
+                .apply(springSecurity())
+                .apply(documentationConfiguration(restDocumentation))
+                .build();
+    }
+
+    @Test
+    @WithCustomMockUser
+    void When_Request_Recommend_Article_Create_With_Post_Method_Expect_HttpStatus_Is_Created() throws Exception {
+        // given
+        ApiResponseDto<String> response = ApiResponseDto.DEFAULT_OK;
+        given(recommendArticleService.createRecommendArticle(EMAIL, ARTICLE_ID)).willReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/articles/{id}/recommend", ARTICLE_ID)
+                .accept(MediaType.APPLICATION_JSON)
+                .header(AUTHORIZATION, VALID_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value("OK"))
+                .andDo(document("create-recommend-article",
+                        ApiDocumentUtil.getDocumentRequest(),
+                        ApiDocumentUtil.getDocumentResponse(),
+                        requestHeaders(headerWithName(AUTHORIZATION).description("Basic auth credentials")),
+                        pathParameters(parameterWithName("id").description("게시글 id"))
+                ));
+
+        verify(recommendArticleService).createRecommendArticle(EMAIL, ARTICLE_ID);
+    }
+
+    @Test
+    @WithCustomMockUser
+    void When_Request_Recommend_Article_Delete_With_Delete_Method_Expect_HttpStatus_Is_OK() throws Exception {
+        // given
+        ApiResponseDto<String> response = ApiResponseDto.DEFAULT_OK;
+        given(recommendArticleService.deleteRecommendArticle(EMAIL, ARTICLE_ID)).willReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(delete("/api/articles/{id}/recommend", ARTICLE_ID)
+                .accept(MediaType.APPLICATION_JSON)
+                .header(AUTHORIZATION, VALID_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("OK"))
+                .andDo(document("delete-recommend-article",
+                        ApiDocumentUtil.getDocumentRequest(),
+                        ApiDocumentUtil.getDocumentResponse(),
+                        requestHeaders(headerWithName(AUTHORIZATION).description("Basic auth credentials")),
+                        pathParameters(parameterWithName("id").description("게시글 id"))
+                ));
+
+        verify(recommendArticleService).deleteRecommendArticle(EMAIL, ARTICLE_ID);
+    }
+}

--- a/src/test/java/com/sedin/qna/recommendarticle/service/RecommendArticleServiceTest.java
+++ b/src/test/java/com/sedin/qna/recommendarticle/service/RecommendArticleServiceTest.java
@@ -1,0 +1,111 @@
+package com.sedin.qna.recommendarticle.service;
+
+import com.sedin.qna.account.model.Account;
+import com.sedin.qna.account.model.Role;
+import com.sedin.qna.account.repository.AccountRepository;
+import com.sedin.qna.article.model.Article;
+import com.sedin.qna.article.repository.ArticleRepository;
+import com.sedin.qna.common.exception.DuplicatedException;
+import com.sedin.qna.common.exception.NotFoundException;
+import com.sedin.qna.common.response.ApiResponseCode;
+import com.sedin.qna.common.response.ApiResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class RecommendArticleServiceTest {
+
+    private static final String EMAIL = "cafe@mocha.com";
+    private static final String PASSWORD = "coffee";
+    private static final String NAME = "mocha";
+    private static final String TITLE = "article title";
+    private static final String CONTENT = "article content";
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private RecommendArticleService recommendArticleService;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    private Account account;
+    private Article article;
+
+    @BeforeEach
+    void setUp() {
+        account = Account.builder()
+                .email(EMAIL)
+                .password(PASSWORD)
+                .name(NAME)
+                .role(Role.USER)
+                .build();
+
+        article = Article.builder()
+                .title(TITLE)
+                .content(CONTENT)
+                .author(account.getName())
+                .account(account)
+                .build();
+
+        accountRepository.save(account);
+        articleRepository.save(article);
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("게시글 추천 생성 시 - 계정, 게시글은 존재하고 추천은 존재 하지 않을 때 - 성공")
+    void createRecommendArticleWithSuccess() {
+        ApiResponseDto<String> response = recommendArticleService.createRecommendArticle(account.getEmail(), article.getId());
+        assertThat(response.getCode()).isSameAs(ApiResponseCode.OK);
+    }
+
+    @Test
+    @DisplayName("게시글 추천 생성 시 - 첫 번째 추천은 성공하고 두 번째 추천은 중복(한 계정당 한 게시글에 추천은 1개만 가능) - 실패")
+    void createRecommendArticleWithFail() {
+        // 첫 번째 추천
+        recommendArticleService.createRecommendArticle(account.getEmail(), article.getId());
+        
+        // 두 번째 추천
+        assertThatThrownBy(() -> recommendArticleService.createRecommendArticle(account.getEmail(), article.getId()))
+                .isInstanceOf(DuplicatedException.class);
+    }
+
+    @Test
+    @DisplayName("게시글 추천 삭제 시 - 계정, 게시글, 추천이 모두 존재할 때 - 성공")
+    void deleteRecommendArticleWithSuccess() {
+        recommendArticleService.createRecommendArticle(account.getEmail(), article.getId());
+        em.flush();
+        em.clear();
+
+        ApiResponseDto<String> response = recommendArticleService.deleteRecommendArticle(account.getEmail(), article.getId());
+        em.flush();
+        em.clear();
+
+        assertThat(response.getCode()).isSameAs(ApiResponseCode.OK);
+    }
+
+    @Test
+    @DisplayName("게시글 추천 삭제 시 - 추천이 존재 하지 않을 때 - 실패")
+    void deleteRecommendArticleWithFail() {
+        assertThatThrownBy(() -> recommendArticleService.deleteRecommendArticle(account.getEmail(), article.getId()))
+                .isInstanceOf(NotFoundException.class);
+    }
+}

--- a/src/test/java/com/sedin/qna/recommendarticle/service/RecommendArticleServiceUnitTest.java
+++ b/src/test/java/com/sedin/qna/recommendarticle/service/RecommendArticleServiceUnitTest.java
@@ -1,0 +1,129 @@
+package com.sedin.qna.recommendarticle.service;
+
+import com.sedin.qna.account.model.Account;
+import com.sedin.qna.account.model.Role;
+import com.sedin.qna.account.repository.AccountRepository;
+import com.sedin.qna.article.model.Article;
+import com.sedin.qna.article.repository.ArticleRepository;
+import com.sedin.qna.common.exception.DuplicatedException;
+import com.sedin.qna.common.exception.NotFoundException;
+import com.sedin.qna.common.response.ApiResponseCode;
+import com.sedin.qna.common.response.ApiResponseDto;
+import com.sedin.qna.recommendarticle.model.RecommendArticle;
+import com.sedin.qna.recommendarticle.repository.RecommendArticleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RecommendArticleServiceUnitTest {
+
+    private static final String EMAIL = "cafe@mocha.com";
+    private static final String NAME = "mocha";
+    private static final String TITLE = "article title";
+    private static final String CONTENT = "article content";
+    private static final Long ACCOUNT_ID = 1L;
+    private static final Long ARTICLE_ID = 1L;
+
+    private RecommendArticleService recommendArticleService;
+
+    @MockBean
+    private AccountRepository accountRepository = mock(AccountRepository.class);
+
+    @MockBean
+    private ArticleRepository articleRepository = mock(ArticleRepository.class);
+
+    @MockBean
+    private RecommendArticleRepository recommendArticleRepository = mock(RecommendArticleRepository.class);
+
+    private Account account;
+    private Article article;
+
+    @BeforeEach
+    void setUp() {
+        recommendArticleService = new RecommendArticleServiceImpl(accountRepository, articleRepository, recommendArticleRepository);
+
+        account = Account.builder()
+                .id(ACCOUNT_ID)
+                .email(EMAIL)
+                .name(NAME)
+                .role(Role.USER)
+                .build();
+
+        article = Article.builder()
+                .id(ARTICLE_ID)
+                .title(TITLE)
+                .content(CONTENT)
+                .author(account.getName())
+                .account(account)
+                .build();
+    }
+
+    @Test
+    @DisplayName("계정, 게시글은 존재하고 추천은 존재하지 않을 때 - 게시글 추천 생성 시 - 등록한다")
+    void createRecommendArticleWithSuccess(){
+        // given
+        when(accountRepository.findByEmail(EMAIL)).thenReturn(Optional.of(account));
+        when(articleRepository.findById(ARTICLE_ID)).thenReturn(Optional.of(article));
+        when(recommendArticleRepository.existsByAccountAndArticle(account, article))
+                .thenReturn(false);
+
+        // when
+        ApiResponseDto<String> response = recommendArticleService.createRecommendArticle(EMAIL, ARTICLE_ID);
+
+        // then
+        assertThat(response.getCode()).isSameAs(ApiResponseCode.OK);
+    }
+
+    @Test
+    @DisplayName("이미 추천이 존재할 때 - 게시글 추천 생성 시 - 중복예외를 던진다")
+    void throwDuplicatedExceptionWithAlreadyExistRecommendArticle(){
+        // given
+        when(accountRepository.findByEmail(EMAIL)).thenReturn(Optional.of(account));
+        when(articleRepository.findById(ARTICLE_ID)).thenReturn(Optional.of(article));
+        when(recommendArticleRepository.existsByAccountAndArticle(account, article))
+                .thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> recommendArticleService.createRecommendArticle(EMAIL, ARTICLE_ID))
+                .isInstanceOf(DuplicatedException.class);
+    }
+
+    @Test
+    @DisplayName("계정, 게시글, 게시글 추천이 존재 할 때 - 게시글 추천 삭제 시 - 삭제한다")
+    void deleteRecommendArticleWithSuccess() {
+        // given
+        RecommendArticle recommendArticle = RecommendArticle.builder()
+                .account(account)
+                .article(article)
+                .build();
+
+        when(accountRepository.findByEmail(EMAIL)).thenReturn(Optional.of(account));
+        when(articleRepository.findById(ARTICLE_ID)).thenReturn(Optional.of(article));
+        when(recommendArticleRepository.findByAccountAndArticle(account, article)).thenReturn(Optional.of(recommendArticle));
+
+        // when
+        ApiResponseDto<String> response = recommendArticleService.deleteRecommendArticle(EMAIL, ARTICLE_ID);
+
+        // then
+        assertThat(response.getCode()).isSameAs(ApiResponseCode.OK);
+    }
+    
+    @Test
+    @DisplayName("게시글 추천이 존재하지 않을 때 - 게시글 추천 삭제 시 - NotFoundException 예외를 던진다")
+    void throwNotFoundExceptionWithNotExistRecommendArticle() {
+        // given
+        when(recommendArticleRepository.findByAccountAndArticle(account, article)).thenThrow(NotFoundException.class);
+
+        // when & then
+        assertThatThrownBy(() -> recommendArticleService.deleteRecommendArticle(EMAIL, ARTICLE_ID))
+                .isInstanceOf(NotFoundException.class);
+    }
+}


### PR DESCRIPTION
- 게시글 추천 수 생성 및 삭제 기능 구현
- 한 게시글에는 한 계정만 추천 가능
- [x] : 게시글 추천 생성 API
- [x] : 게시글 추천 삭제 API
- [x] : RecommendArticle MockMVC Test 작성
- [x] : RecommendArticleService Unit Test 작성
- [x] : RecommendArticleService 통합 Test 작성
- [x] : 게시글 추천 API RestDocs 문서화
     - [x] : RecommendArticle 문서화를 위한 asciidoc 템플릿 추가

closes #29 