### PR TITLE
게시글 전체 조회 & 단건 조회 시 게시글 추천 수 보여주는 기능 구현

### DIFF
--- a/src/main/java/com/sedin/qna/article/model/Article.java
+++ b/src/main/java/com/sedin/qna/article/model/Article.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Formula;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -47,6 +48,9 @@ public class Article extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Long articleViewCount = 0L;
+
+    @Formula("(select count(r.recommend_article_id) from recommend_article r where r.article_id = article_id)")
+    private Long recommendArticleCount = 0L;
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();

--- a/src/main/java/com/sedin/qna/article/model/Article.java
+++ b/src/main/java/com/sedin/qna/article/model/Article.java
@@ -3,6 +3,7 @@ package com.sedin.qna.article.model;
 import com.sedin.qna.account.model.Account;
 import com.sedin.qna.comment.model.Comment;
 import com.sedin.qna.common.model.BaseTimeEntity;
+import com.sedin.qna.recommendarticle.model.RecommendArticle;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,6 +47,9 @@ public class Article extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Long articleViewCount = 0L;
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
+    private List<RecommendArticle> recommendArticles = new ArrayList<>();
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();

--- a/src/main/java/com/sedin/qna/article/model/Article.java
+++ b/src/main/java/com/sedin/qna/article/model/Article.java
@@ -3,7 +3,6 @@ package com.sedin.qna.article.model;
 import com.sedin.qna.account.model.Account;
 import com.sedin.qna.comment.model.Comment;
 import com.sedin.qna.common.model.BaseTimeEntity;
-import com.sedin.qna.recommendarticle.model.RecommendArticle;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/sedin/qna/article/model/Article.java
+++ b/src/main/java/com/sedin/qna/article/model/Article.java
@@ -49,9 +49,6 @@ public class Article extends BaseTimeEntity {
     private Long articleViewCount = 0L;
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
-    private List<RecommendArticle> recommendArticles = new ArrayList<>();
-
-    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/sedin/qna/article/model/ArticleDto.java
+++ b/src/main/java/com/sedin/qna/article/model/ArticleDto.java
@@ -136,14 +136,14 @@ public class ArticleDto {
             this.modifiedAt = modifiedAt;
         }
 
-        public static ResponseAll of(Article article, Long recommendArticleCount) {
+        public static ResponseAll of(Article article) {
             return ResponseAll.builder()
                     .id(article.getId())
                     .title(article.getTitle())
                     .author(article.getAuthor())
                     .commentsCount(article.getCommentsCount())
                     .articleViewCount(article.getArticleViewCount())
-                    .recommendArticleCount(recommendArticleCount)
+                    .recommendArticleCount(article.getRecommendArticleCount())
                     .createdAt(article.getCreatedAt())
                     .modifiedAt(article.getModifiedAt())
                     .build();
@@ -182,7 +182,7 @@ public class ArticleDto {
             this.modifiedAt = modifiedAt;
         }
 
-        public static ResponseDetail of(Article article, Long recommendArticleCount) {
+        public static ResponseDetail of(Article article) {
             return ResponseDetail.builder()
                     .id(article.getId())
                     .title(article.getTitle())
@@ -190,7 +190,7 @@ public class ArticleDto {
                     .author(article.getAuthor())
                     .commentsCount(article.getCommentsCount())
                     .articleViewCount(article.getArticleViewCount())
-                    .recommendArticleCount(recommendArticleCount)
+                    .recommendArticleCount(article.getRecommendArticleCount())
                     .comments(article.getComments().stream().map(CommentDto.Response::of).collect(Collectors.toList()))
                     .createdAt(article.getCreatedAt())
                     .modifiedAt(article.getModifiedAt())

--- a/src/main/java/com/sedin/qna/article/model/ArticleDto.java
+++ b/src/main/java/com/sedin/qna/article/model/ArticleDto.java
@@ -136,14 +136,14 @@ public class ArticleDto {
             this.modifiedAt = modifiedAt;
         }
 
-        public static ResponseAll of(Article article) {
+        public static ResponseAll of(Article article, Long recommendArticleCount) {
             return ResponseAll.builder()
                     .id(article.getId())
                     .title(article.getTitle())
                     .author(article.getAuthor())
                     .commentsCount(article.getCommentsCount())
                     .articleViewCount(article.getArticleViewCount())
-                    .recommendArticleCount((long) article.getRecommendArticles().size())
+                    .recommendArticleCount(recommendArticleCount)
                     .createdAt(article.getCreatedAt())
                     .modifiedAt(article.getModifiedAt())
                     .build();
@@ -182,7 +182,7 @@ public class ArticleDto {
             this.modifiedAt = modifiedAt;
         }
 
-        public static ResponseDetail of(Article article) {
+        public static ResponseDetail of(Article article, Long recommendArticleCount) {
             return ResponseDetail.builder()
                     .id(article.getId())
                     .title(article.getTitle())
@@ -190,7 +190,7 @@ public class ArticleDto {
                     .author(article.getAuthor())
                     .commentsCount(article.getCommentsCount())
                     .articleViewCount(article.getArticleViewCount())
-                    .recommendArticleCount((long) article.getRecommendArticles().size())
+                    .recommendArticleCount(recommendArticleCount)
                     .comments(article.getComments().stream().map(CommentDto.Response::of).collect(Collectors.toList()))
                     .createdAt(article.getCreatedAt())
                     .modifiedAt(article.getModifiedAt())

--- a/src/main/java/com/sedin/qna/article/model/ArticleDto.java
+++ b/src/main/java/com/sedin/qna/article/model/ArticleDto.java
@@ -116,6 +116,7 @@ public class ArticleDto {
         private String author;
         private Long commentsCount;
         private Long articleViewCount;
+        private Long recommendArticleCount;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
         private LocalDateTime createdAt;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
@@ -123,12 +124,14 @@ public class ArticleDto {
 
         @Builder
         private ResponseAll(Long id, String title, String author, Long commentsCount,
-                            Long articleViewCount, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+                            Long articleViewCount, Long recommendArticleCount,
+                            LocalDateTime createdAt, LocalDateTime modifiedAt) {
             this.id = id;
             this.title = title;
             this.author = author;
             this.commentsCount = commentsCount;
             this.articleViewCount = articleViewCount;
+            this.recommendArticleCount = recommendArticleCount;
             this.createdAt = createdAt;
             this.modifiedAt = modifiedAt;
         }
@@ -140,6 +143,7 @@ public class ArticleDto {
                     .author(article.getAuthor())
                     .commentsCount(article.getCommentsCount())
                     .articleViewCount(article.getArticleViewCount())
+                    .recommendArticleCount((long) article.getRecommendArticles().size())
                     .createdAt(article.getCreatedAt())
                     .modifiedAt(article.getModifiedAt())
                     .build();
@@ -155,6 +159,7 @@ public class ArticleDto {
         private String author;
         private Long commentsCount;
         private Long articleViewCount;
+        private Long recommendArticleCount;
         private List<CommentDto.Response> comments;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
         private LocalDateTime createdAt;
@@ -163,7 +168,7 @@ public class ArticleDto {
 
         @Builder
         private ResponseDetail(Long id, String title, String content, String author, Long commentsCount,
-                               Long articleViewCount, List<CommentDto.Response> comments,
+                               Long articleViewCount, Long recommendArticleCount, List<CommentDto.Response> comments,
                                LocalDateTime createdAt, LocalDateTime modifiedAt) {
             this.id = id;
             this.title = title;
@@ -171,6 +176,7 @@ public class ArticleDto {
             this.author = author;
             this.commentsCount = commentsCount;
             this.articleViewCount = articleViewCount;
+            this.recommendArticleCount = recommendArticleCount;
             this.comments = comments;
             this.createdAt = createdAt;
             this.modifiedAt = modifiedAt;
@@ -184,6 +190,7 @@ public class ArticleDto {
                     .author(article.getAuthor())
                     .commentsCount(article.getCommentsCount())
                     .articleViewCount(article.getArticleViewCount())
+                    .recommendArticleCount((long) article.getRecommendArticles().size())
                     .comments(article.getComments().stream().map(CommentDto.Response::of).collect(Collectors.toList()))
                     .createdAt(article.getCreatedAt())
                     .modifiedAt(article.getModifiedAt())

--- a/src/main/java/com/sedin/qna/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sedin/qna/article/service/ArticleServiceImpl.java
@@ -7,7 +7,6 @@ import com.sedin.qna.article.model.ArticleDto;
 import com.sedin.qna.article.repository.ArticleRepository;
 import com.sedin.qna.common.exception.NotFoundException;
 import com.sedin.qna.common.exception.PermissionToAccessException;
-import com.sedin.qna.recommendarticle.repository.RecommendArticleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -23,7 +22,6 @@ public class ArticleServiceImpl implements ArticleService {
 
     private final AccountRepository accountRepository;
     private final ArticleRepository articleRepository;
-    private final RecommendArticleRepository recommendArticleRepository;
 
     @Override
     public ArticleDto.ResponseChange create(String email, ArticleDto.Create create) {
@@ -36,7 +34,7 @@ public class ArticleServiceImpl implements ArticleService {
     @Transactional(readOnly = true)
     public List<ArticleDto.ResponseAll> findAll(Pageable pageable) {
         return articleRepository.findAll(pageable).stream()
-                .map(article -> ArticleDto.ResponseAll.of(article, recommendArticleRepository.countByArticle(article)))
+                .map(ArticleDto.ResponseAll::of)
                 .collect(Collectors.toList());
     }
 
@@ -44,7 +42,7 @@ public class ArticleServiceImpl implements ArticleService {
     public ArticleDto.ResponseDetail findById(Long id) {
         Article article = findArticle(id);
         article.increaseArticleViewCount();
-        return ArticleDto.ResponseDetail.of(article, recommendArticleRepository.countByArticle(article));
+        return ArticleDto.ResponseDetail.of(article);
     }
 
     @Override
@@ -68,7 +66,7 @@ public class ArticleServiceImpl implements ArticleService {
     @Override
     public List<ArticleDto.ResponseDetail> findAllWithComments(Pageable pageable) {
         return articleRepository.findAllEntityGraph(pageable).stream()
-                .map(article -> ArticleDto.ResponseDetail.of(article, recommendArticleRepository.countByArticle(article)))
+                .map(ArticleDto.ResponseDetail::of)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/sedin/qna/recommendarticle/repository/RecommendArticleRepository.java
+++ b/src/main/java/com/sedin/qna/recommendarticle/repository/RecommendArticleRepository.java
@@ -14,4 +14,6 @@ public interface RecommendArticleRepository extends JpaRepository<RecommendArtic
     boolean existsByAccountAndArticle(Account account, Article article);
 
     Optional<RecommendArticle> findByAccountAndArticle(Account account, Article article);
+
+    Long countByArticle(Article article);
 }

--- a/src/test/java/com/sedin/qna/article/controller/ArticleControllerWebTest.java
+++ b/src/test/java/com/sedin/qna/article/controller/ArticleControllerWebTest.java
@@ -178,6 +178,7 @@ class ArticleControllerWebTest {
                         .author(AUTHOR)
                         .commentsCount(0L)
                         .articleViewCount(0L)
+                        .recommendArticleCount(0L)
                         .createdAt(LocalDateTime.now())
                         .modifiedAt(LocalDateTime.now())
                         .build(),
@@ -187,6 +188,7 @@ class ArticleControllerWebTest {
                         .author(AUTHOR)
                         .commentsCount(0L)
                         .articleViewCount(0L)
+                        .recommendArticleCount(0L)
                         .createdAt(LocalDateTime.now())
                         .modifiedAt(LocalDateTime.now())
                         .build()
@@ -220,6 +222,7 @@ class ArticleControllerWebTest {
                                         fieldWithPath("author").type(JsonFieldType.STRING).description("작성자"),
                                         fieldWithPath("commentsCount").type(JsonFieldType.NUMBER).description("댓글 수"),
                                         fieldWithPath("articleViewCount").type(JsonFieldType.NUMBER).description("조회 수"),
+                                        fieldWithPath("recommendArticleCount").type(JsonFieldType.NUMBER).description("게시글 추천 수"),
                                         fieldWithPath("createdAt").type(JsonFieldType.STRING)
                                                 .attributes(DocumentFormatGenerator.getDateFormat())
                                                 .description("생성시간"),
@@ -242,6 +245,7 @@ class ArticleControllerWebTest {
                 .author(AUTHOR)
                 .commentsCount(0L)
                 .articleViewCount(0L)
+                .recommendArticleCount(0L)
                 .comments(new ArrayList<>())
                 .createdAt(LocalDateTime.now())
                 .modifiedAt(LocalDateTime.now())
@@ -271,6 +275,7 @@ class ArticleControllerWebTest {
                                         fieldWithPath("author").type(JsonFieldType.STRING).description("작성자"),
                                         fieldWithPath("commentsCount").type(JsonFieldType.NUMBER).description("댓글 수"),
                                         fieldWithPath("articleViewCount").type(JsonFieldType.NUMBER).description("조회 수"),
+                                        fieldWithPath("recommendArticleCount").type(JsonFieldType.NUMBER).description("게시글 추천 수"),
                                         fieldWithPath("comments").type(JsonFieldType.ARRAY).description("댓글"),
                                         fieldWithPath("createdAt").type(JsonFieldType.STRING)
                                                 .attributes(DocumentFormatGenerator.getDateFormat())

--- a/src/test/java/com/sedin/qna/recommendarticle/controller/RecommendArticleControllerTest.java
+++ b/src/test/java/com/sedin/qna/recommendarticle/controller/RecommendArticleControllerTest.java
@@ -1,14 +1,11 @@
 package com.sedin.qna.recommendarticle.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sedin.qna.account.model.Account;
 import com.sedin.qna.authentication.service.JwtTokenProvider;
 import com.sedin.qna.common.configuration.SecurityConfiguration;
 import com.sedin.qna.common.response.ApiResponseDto;
 import com.sedin.qna.configuration.WithCustomMockUser;
 import com.sedin.qna.recommendarticle.service.RecommendArticleService;
 import com.sedin.qna.util.ApiDocumentUtil;
-import com.sedin.qna.util.DocumentFormatGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,18 +18,14 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -40,16 +33,10 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -104,8 +91,7 @@ class RecommendArticleControllerTest {
                 .characterEncoding(StandardCharsets.UTF_8));
 
         // then
-        result.andDo(print())
-                .andExpect(status().isCreated())
+        result.andExpect(status().isCreated())
                 .andExpect(jsonPath("$.code").value("OK"))
                 .andDo(document("create-recommend-article",
                         ApiDocumentUtil.getDocumentRequest(),
@@ -132,8 +118,7 @@ class RecommendArticleControllerTest {
                 .characterEncoding(StandardCharsets.UTF_8));
 
         // then
-        result.andDo(print())
-                .andExpect(status().isOk())
+        result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("OK"))
                 .andDo(document("delete-recommend-article",
                         ApiDocumentUtil.getDocumentRequest(),


### PR DESCRIPTION
- [X] : Article Entity에 `@Formula`를 사용하여 subquery로 해당 게시글의 총 추천 수 구해옴
- [X] : Article 전체 조회(페이징 적용)에 응답 Response에 추천 수 추가하여 기능 구현
- [X] : Article 단건 조회에 응답 Response에 추천 수 추가하여 기능 구현
- [X] : 요구사항 변경으로 인해 깨지는 테스트 수정
- [X] : 추천 수 조회 RestDocs에 적용

closes #35 